### PR TITLE
Add dirty tracking for resources

### DIFF
--- a/lib/ledger_sync/resource.rb
+++ b/lib/ledger_sync/resource.rb
@@ -27,7 +27,7 @@ module LedgerSync
 
     serialize except: %i[attributes references]
 
-    attr_accessor :external_id, :ledger_id, :sync_token
+    dirty_attribute :external_id, :ledger_id, :sync_token
 
     def initialize(external_id: nil, ledger_id: nil, sync_token: nil, **data)
       @external_id = external_id.to_s.to_sym

--- a/lib/ledger_sync/resource.rb
+++ b/lib/ledger_sync/resource.rb
@@ -30,7 +30,7 @@ module LedgerSync
     dirty_attribute :external_id, :ledger_id, :sync_token
 
     def initialize(external_id: nil, ledger_id: nil, sync_token: nil, **data)
-      @external_id = external_id.to_s.to_sym
+      @external_id = external_id.try(:to_sym)
       @ledger_id = ledger_id
       @sync_token = sync_token
 

--- a/lib/ledger_sync/resource_attribute.rb
+++ b/lib/ledger_sync/resource_attribute.rb
@@ -12,6 +12,9 @@ end
 
 module LedgerSync
   class ResourceAttribute
+    include Fingerprintable::Mixin
+    include SimplySerializable::Mixin
+
     attr_accessor :value
     attr_reader :name,
                 :reference,

--- a/lib/ledger_sync/resource_attribute.rb
+++ b/lib/ledger_sync/resource_attribute.rb
@@ -36,6 +36,9 @@ module LedgerSync
       type.cast(value)
     end
 
+    # This is for ActiveModel::Dirty, since we define @attributes
+    def forgetting_assignment; end
+
     def reference?
       is_a?(Reference)
     end

--- a/lib/ledger_sync/resource_attribute/dirty_mixin.rb
+++ b/lib/ledger_sync/resource_attribute/dirty_mixin.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Helper methods for adding dirty tracked attributes
+module LedgerSync
+  class ResourceAttribute
+    module DirtyMixin
+      def self.included(base)
+        base.include(ActiveModel::Dirty)
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def dirty_attribute(*names)
+          names.each do |name|
+            class_eval do
+              attr_reader name
+              define_attribute_methods name # From ActiveModel
+              dirty_attributes[name] = {
+                name: name
+              }
+
+              define_method("#{name}=") do |val|
+                send("#{name}_will_change!") unless val == instance_variable_get("@#{name}")
+                instance_variable_set("@#{name}", val)
+              end
+            end
+          end
+        end
+
+        def dirty_attributes
+          @dirty_attributes ||= {}
+        end
+      end
+
+      def save
+        changes_applied
+      end
+    end
+  end
+end

--- a/lib/ledger_sync/resource_attribute/dirty_mixin.rb
+++ b/lib/ledger_sync/resource_attribute/dirty_mixin.rb
@@ -32,8 +32,17 @@ module LedgerSync
         end
       end
 
+      # Normally you would just call `changes_applied`, but because we
+      # define an `@attributes` instance variable, the `ActiveModel::Dirty`
+      # mixin assumes it is a list of attributes in their format (spoiler: it
+      # isn't).  So this is copying the code from `changes_applied` and setting
+      # `@mutations_from_database` to the value it would receive if
+      # `@attributes` did not exist.
       def save
-        changes_applied
+        # changes_applied # Code reproduced below.
+        @mutations_before_last_save = mutations_from_database
+        # forget_attribute_assignments # skipped as our attributes do not implement this method
+        @mutations_from_database = ActiveModel::ForcedMutationTracker.new(self) # Manually set to expected value
       end
     end
   end

--- a/lib/ledger_sync/resource_attribute/mixin.rb
+++ b/lib/ledger_sync/resource_attribute/mixin.rb
@@ -1,23 +1,29 @@
 # frozen_string_literal: true
 
 require_relative '../resource_attribute_set'
+require_relative 'dirty_mixin'
 
 # Mixin for attribute functionality
 module LedgerSync
   class ResourceAttribute
     module Mixin
       def self.included(base)
+        base.include(DirtyMixin)
         base.extend(ClassMethods)
       end
 
       module ClassMethods
         def _define_attribute_methods(name)
           class_eval do
+            define_attribute_methods name
+
             define_method name do
               attributes[name].value
             end
 
             define_method "#{name}=" do |val|
+              public_send("#{name}_will_change!") unless val == attributes[name] # For Dirty
+
               attribute = attributes[name]
 
               unless attribute.valid_with?(value: val)

--- a/lib/ledger_sync/resource_attribute_set.rb
+++ b/lib/ledger_sync/resource_attribute_set.rb
@@ -9,9 +9,11 @@ module LedgerSync
                 :resource
 
     delegate  :[],
+              :each,
+              :include?,
               :key?,
               :keys,
-              :include?,
+              :map,
               to: :attributes
 
     alias names keys
@@ -43,6 +45,10 @@ module LedgerSync
       end
 
       @attributes[attribute.name] = attribute
+    end
+
+    def to_a
+      attributes.values
     end
 
     def to_h

--- a/lib/ledger_sync/resource_attribute_set.rb
+++ b/lib/ledger_sync/resource_attribute_set.rb
@@ -11,7 +11,9 @@ module LedgerSync
     delegate  :[],
               :key?,
               :keys,
+              :include?,
               to: :attributes
+
     alias names keys
 
     def initialize(resource:)

--- a/spec/resources/dirty_spec.rb
+++ b/spec/resources/dirty_spec.rb
@@ -3,48 +3,64 @@ require 'spec_helper'
 RSpec.describe LedgerSync::Resource do
   let(:resource) { LedgerSync::Customer.new }
 
+
   it do
     expect(resource).not_to be_changed
+    expect(resource.external_id).to be_nil
     resource.external_id = :asdf
+    expect(resource.external_id).to eq(:asdf)
     expect(resource).to be_changed
     expect(resource.changes).to have_key('external_id')
     resource.save
     expect(resource).not_to be_changed
+    expect(resource.external_id).to eq(:asdf)
   end
 
   it do
     expect(resource).not_to be_changed
+    expect(resource.sync_token).to be_nil
     resource.sync_token = :asdf
+    expect(resource.sync_token).to eq(:asdf)
     expect(resource).to be_changed
     expect(resource.changes).to have_key('sync_token')
     resource.save
     expect(resource).not_to be_changed
+    expect(resource.sync_token).to eq(:asdf)
   end
 
   it do
     expect(resource).not_to be_changed
+    expect(resource.ledger_id).to be_nil
     resource.ledger_id = :asdf
+    expect(resource.ledger_id).to eq(:asdf)
     expect(resource).to be_changed
     expect(resource.changes).to have_key('ledger_id')
     resource.save
     expect(resource).not_to be_changed
+    expect(resource.ledger_id).to eq(:asdf)
   end
 
   it do
     expect(resource).not_to be_changed
+    expect(resource.name).to be_nil
     resource.name = 'asdf'
+    expect(resource.name).to eq('asdf')
     expect(resource).to be_changed
     expect(resource.changes).to have_key('name')
     resource.save
     expect(resource).not_to be_changed
+    expect(resource.name).to eq('asdf')
   end
 
   it do
     expect(resource).not_to be_changed
+    expect(resource.phone_number).to be_nil
     resource.phone_number = 'asdf'
+    expect(resource.phone_number).to eq('asdf')
     expect(resource).to be_changed
     expect(resource.changes).to have_key('phone_number')
     resource.save
     expect(resource).not_to be_changed
+    expect(resource.phone_number).to eq('asdf')
   end
 end

--- a/spec/resources/dirty_spec.rb
+++ b/spec/resources/dirty_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe LedgerSync::Resource do
+  let(:resource) { LedgerSync::Customer.new }
+
+  it do
+    expect(resource).not_to be_changed
+    resource.external_id = :asdf
+    expect(resource).to be_changed
+    expect(resource.changes).to have_key('external_id')
+  end
+
+  it do
+    expect(resource).not_to be_changed
+    resource.sync_token = :asdf
+    expect(resource).to be_changed
+    expect(resource.changes).to have_key('sync_token')
+  end
+
+  it do
+    expect(resource).not_to be_changed
+    resource.ledger_id = :asdf
+    expect(resource).to be_changed
+    expect(resource.changes).to have_key('ledger_id')
+  end
+
+  it do
+    expect(resource).not_to be_changed
+    resource.name = 'asdf'
+    expect(resource).to be_changed
+    expect(resource.changes).to have_key('name')
+  end
+
+  it do
+    expect(resource).not_to be_changed
+    resource.phone_number = 'asdf'
+    expect(resource).to be_changed
+    expect(resource.changes).to have_key('phone_number')
+  end
+end

--- a/spec/resources/dirty_spec.rb
+++ b/spec/resources/dirty_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe LedgerSync::Resource do
     resource.external_id = :asdf
     expect(resource).to be_changed
     expect(resource.changes).to have_key('external_id')
+    resource.save
+    expect(resource).not_to be_changed
   end
 
   it do
@@ -15,6 +17,8 @@ RSpec.describe LedgerSync::Resource do
     resource.sync_token = :asdf
     expect(resource).to be_changed
     expect(resource.changes).to have_key('sync_token')
+    resource.save
+    expect(resource).not_to be_changed
   end
 
   it do
@@ -22,6 +26,8 @@ RSpec.describe LedgerSync::Resource do
     resource.ledger_id = :asdf
     expect(resource).to be_changed
     expect(resource.changes).to have_key('ledger_id')
+    resource.save
+    expect(resource).not_to be_changed
   end
 
   it do
@@ -29,6 +35,8 @@ RSpec.describe LedgerSync::Resource do
     resource.name = 'asdf'
     expect(resource).to be_changed
     expect(resource.changes).to have_key('name')
+    resource.save
+    expect(resource).not_to be_changed
   end
 
   it do
@@ -36,5 +44,7 @@ RSpec.describe LedgerSync::Resource do
     resource.phone_number = 'asdf'
     expect(resource).to be_changed
     expect(resource.changes).to have_key('phone_number')
+    resource.save
+    expect(resource).not_to be_changed
   end
 end

--- a/spec/serializable/operation_spec.rb
+++ b/spec/serializable/operation_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe LedgerSync::Adaptors::Test::Customer::Operations::Create, type: :
         'LedgerSync::Customer/d9f523a3395af66f5bfe48b79e657b34' => {
           data: {
             email: nil,
-            external_id: :"",
+            external_id: nil,
             ledger_id: 'asdf',
             name: 'asdf',
             phone_number: nil,

--- a/spec/serializable/resource_spec.rb
+++ b/spec/serializable/resource_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe LedgerSync::Resource, type: :serializable do
         'LedgerSync::Customer/f402c4135c3b4ae1302a154da0740995' => {
           data: {
             email: nil,
-            external_id: :"",
+            external_id: nil,
             ledger_id: nil,
             name: 'John Doe',
             phone_number: nil,
@@ -32,7 +32,7 @@ RSpec.describe LedgerSync::Resource, type: :serializable do
               id: 'LedgerSync::Customer/f402c4135c3b4ae1302a154da0740995',
               object: :reference
             },
-            external_id: :"",
+            external_id: nil,
             ledger_id: nil,
             sync_token: nil
           },

--- a/spec/serializable/result_spec.rb
+++ b/spec/serializable/result_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe LedgerSync::Result, type: :serializable do
           'LedgerSync::Customer/0bce46b00949dc9db1d717d38ea9356c' => {
             data: {
               email: nil,
-              external_id: :"",
+              external_id: nil,
               ledger_id: :asdf,
               name: 'Test customer 0',
               phone_number: nil,
@@ -196,7 +196,7 @@ RSpec.describe LedgerSync::Result, type: :serializable do
           'LedgerSync::Customer/8fd0a86b38a3a4e127389d97a3782606' => {
             data: {
               email: nil,
-              external_id: :"",
+              external_id: nil,
               ledger_id: :asdf,
               name: 'Test customer 1',
               phone_number: nil,
@@ -287,7 +287,7 @@ RSpec.describe LedgerSync::Result, type: :serializable do
           'LedgerSync::Customer/0bce46b00949dc9db1d717d38ea9356c' => {
             data: {
               email: nil,
-              external_id: :"",
+              external_id: nil,
               ledger_id: :asdf,
               name: 'Test customer 0',
               phone_number: nil,
@@ -300,7 +300,7 @@ RSpec.describe LedgerSync::Result, type: :serializable do
           'LedgerSync::Customer/8fd0a86b38a3a4e127389d97a3782606' => {
             data: {
               email: nil,
-              external_id: :"",
+              external_id: nil,
               ledger_id: :asdf,
               name: 'Test customer 1',
               phone_number: nil,


### PR DESCRIPTION
Fix #8 

This is dependent and based off of #7, so it needs to be merged first and then this base needs shifted to `master`.

Uses ActiveModel::Dirty to track if attributes have changed.  Note: You must call `resource.save` to reset the dirty tracking.  This isn't plugged in anywhere yet.  Just the core code and tests.

@mattgmarcus @jozefvaclavik Let me know if you think anything else needs to go in this.