### PR TITLE
Updating customer without data should not set null values

### DIFF
--- a/lib/ledger_sync/adaptors/quickbooks_online/customer/operations/update.rb
+++ b/lib/ledger_sync/adaptors/quickbooks_online/customer/operations/update.rb
@@ -10,7 +10,7 @@ module LedgerSync
               params do
                 required(:ledger_id).filled(:string)
                 required(:email).maybe(:string)
-                required(:name).filled(:string)
+                required(:name).maybe(:string)
                 required(:phone_number).maybe(:string)
               end
             end

--- a/spec/integrations/quickbooks_online/customers/update_spec.rb
+++ b/spec/integrations/quickbooks_online/customers/update_spec.rb
@@ -37,4 +37,30 @@ RSpec.describe 'quickbooks_online/customers/update', type: :feature do
     it { expect(subject).to be_success }
     it { expect(subject).to be_a(LedgerSync::SyncResult::Success) }
   end
+
+  describe 'zero input' do
+    let(:zero_input) do
+      {
+        adaptor: quickbooks_adaptor,
+        resource_external_id: :c1,
+        resource_type: 'customer',
+        method: :update,
+        resources_data: customer_resources(ledger_id: '123', data: {})
+      }
+    end
+
+    it { expect(LedgerSync::Sync.new(**zero_input)).to be_valid }
+
+    context '#operations' do
+      subject { LedgerSync::Sync.new(**zero_input).operations }
+      it { expect(subject.length).to eq(1) }
+      it { expect(subject.first).to be_a(LedgerSync::Adaptors::QuickBooksOnline::Customer::Operations::Update) }
+    end
+
+    context '#perform' do
+      subject { LedgerSync::Sync.new(**zero_input).perform }
+      it { expect(subject).to be_success }
+      it { expect(subject).to be_a(LedgerSync::SyncResult::Success) }
+    end
+  end
 end


### PR DESCRIPTION
This is a use-case where we need dirty attributes. 

Ledger will try to make a QBO request with set `null` values. With dirty attributes we could avoid setting `null` and instead send original (fetched) values

`"{\"Taxable\":true,\"Job\":false,\"BillWithParent\":false,\"Balance\":0,\"BalanceWithJobs\":0,\"CurrencyRef\":{\"value\":\"USD\",\"name\":\"United States Dollar\"},\"PreferredDeliveryMethod\":\"Print\",\"domain\":\"QBO\",\"sparse\":false,\"Id\":\"66\",\"SyncToken\":\"0\",\"MetaData\":{\"CreateTime\":\"2019-07-11T13:04:17-07:00\",\"LastUpdatedTime\":\"2019-07-11T13:04:17-07:00\"},\"FullyQualifiedName\":\"Sample Customer\",\"DisplayName\":\"Sample Customer\",\"PrintOnCheckName\":\"Sample Customer\",\"Active\":true,\"PrimaryEmailAddr\":{\"Address\":null},\"DefaultTaxCodeRef\":{\"value\":\"2\"},\"PrimaryPhone\":{\"FreeFormNumber\":null}}"`