### PR TITLE
Cleanup Upsert

### DIFF
--- a/lib/ledger_sync/adaptors/quickbooks_online/expense/operations/create.rb
+++ b/lib/ledger_sync/adaptors/quickbooks_online/expense/operations/create.rb
@@ -19,8 +19,6 @@ module LedgerSync
               end
             end
 
-            private
-
             def build
               build_account_operation(resource.account)
               resource.line_items.each do |line_item|
@@ -29,6 +27,8 @@ module LedgerSync
               build_vendor_operation
               add_root_operation(self)
             end
+
+            private
 
             def operate
               response = adaptor.upsert(

--- a/lib/ledger_sync/adaptors/quickbooks_online/expense/operations/update.rb
+++ b/lib/ledger_sync/adaptors/quickbooks_online/expense/operations/update.rb
@@ -19,8 +19,6 @@ module LedgerSync
               end
             end
 
-            private
-
             def build
               build_account_operation(resource.account)
               resource.line_items.each do |line_item|
@@ -29,6 +27,8 @@ module LedgerSync
               build_vendor_operation
               add_root_operation(self)
             end
+
+            private
 
             def operate
               ledger_resource_data = adaptor.find(

--- a/lib/ledger_sync/adaptors/quickbooks_online/expense/operations/upsert.rb
+++ b/lib/ledger_sync/adaptors/quickbooks_online/expense/operations/upsert.rb
@@ -19,50 +19,26 @@ module LedgerSync
               end
             end
 
-            private
-
             def build
-              op = if qbo_expense?
-                     Update.new(adaptor: adaptor, resource: resource)
-                   else
-                     Create.new(adaptor: adaptor, resource: resource)
-                   end
-
-              build_account_operation(resource.account)
-              resource.line_items.each do |line_item|
-                build_account_operation(line_item.account)
+              op = if find_result.success?
+                Update.new(adaptor: adaptor, resource: resource)
+              else
+                Create.new(adaptor: adaptor, resource: resource)
               end
-              build_vendor_operation
-              add_root_operation(op)
+              op.build
+
+              op.before_operations.each {|o| add_before_operation(o)}
+              op.after_operations.each {|o| add_after_operation(o)}
+              add_root_operation(op.root_operation)
             end
 
-            def build_account_operation(account)
-              account_op = Account::Operations::Upsert.new(
-                adaptor: adaptor,
-                resource: account
-              )
-
-              add_before_operation(account_op)
-            end
-
-            def build_vendor_operation
-              vendor = Vendor::Operations::Upsert.new(
-                adaptor: adaptor,
-                resource: resource.vendor
-              )
-
-              add_before_operation(vendor)
-            end
+            private
 
             def find_result
               @find_result ||= Find.new(
                 adaptor: adaptor,
                 resource: resource
               ).perform
-            end
-
-            def qbo_expense?
-              find_result.success?
             end
           end
         end


### PR DESCRIPTION
I would call this as a proof of concept for now.

Currently our `Upsert` operation needs to specify all related operations and then it sets `root_operation` as either `Create` or `Update`. But these two operations knows better what related operations they require (it could be different).

This way we let `Create`/`Update` operation to build necessary required operations and use those instead.