### PR TITLE
Move active_model to runtime dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ledger_sync (1.0.10)
+      activemodel
       colorize
       coveralls
       dry-schema
@@ -164,7 +165,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activemodel
   awesome_print
   bump
   bundler (~> 1.16)

--- a/ledger_sync.gemspec
+++ b/ledger_sync.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency('activemodel', '>= 0')
   spec.add_development_dependency('awesome_print', '>= 0')
   spec.add_development_dependency('bump')
   spec.add_development_dependency('bundler', '~> 1.16')
@@ -37,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rubocop', '>= 0')
   spec.add_development_dependency('vcr', '>= 0')
   spec.add_development_dependency('webmock', '>= 0')
+  spec.add_runtime_dependency('activemodel', '>= 0')
   spec.add_runtime_dependency('colorize', '>= 0')
   spec.add_runtime_dependency('coveralls')
   spec.add_runtime_dependency('dry-schema')


### PR DESCRIPTION
This was in the wrong gem group.  Probably didn't see an error since we were using the app in rails apps to begin with.