### PR TITLE
Deep merge hashes in array

### DIFF
--- a/spec/adaptors/operation_spec.rb
+++ b/spec/adaptors/operation_spec.rb
@@ -173,6 +173,48 @@ RSpec.describe LedgerSync::Adaptors::Operation do
 
       expect(subject.merge_into(from: h1, to: h2)).to eq(h)
     end
+
+    it do
+      h1 = {
+        'a' => 1,
+        'b' => [{'Id' => 1, 'x' => 1}]
+      }
+
+      h2 = {
+        'a' => 2,
+        'b' => [{'Id' => 1, 'x' => 10, 'xx' => 1}, {'y' => 20, 'yy' => 2}],
+        'c' => 3
+      }
+
+      h = {
+        'a' => 1,
+        'b' => [{'Id' => 1, 'x' => 1, 'xx' => 1}],
+        'c' => 3
+      }
+
+      expect(subject.merge_into(from: h1, to: h2)).to eq(h)
+    end
+
+    it do
+      h1 = {
+        'a' => 1,
+        'b' => [{'Id' => 1, 'x' => 1}, {'z' => 30}]
+      }
+
+      h2 = {
+        'a' => 2,
+        'b' => [{'Id' => 1, 'x' => 10, 'xx' => 1}, {'Id' => 4, 'y' => 20, 'yy' => 2}],
+        'c' => 3
+      }
+
+      h = {
+        'a' => 1,
+        'b' => [{'Id' => 1, 'x' => 1, 'xx' => 1}, {'z' => 30}],
+        'c' => 3
+      }
+
+      expect(subject.merge_into(from: h1, to: h2)).to eq(h)
+    end
   end
 
   describe '#perform' do


### PR DESCRIPTION
_Some_ line items has IDs. The way we merged payloads was to override arrays in fetched payload with values from our payload.

QBO luckily handles update as _replace_. So any previous line items gets deleted and new are created.

The issue becomes if user changes some attribute in QBO on a line item (lets say tax category) that we don't handle.

If we don't preserve ID of line item and push update, we basically remove that line item and create new one with _default_ values for attributes we don't set (mostly null).

If we preserve ID of line item and we pass it as it in next update, QBO performs update on a line item instead of creating new one.

This PR updates `merge_into` method to deep merge arrays of hashes. It does `map` on new array and tries to lookup/find match in old array by `Id` (which is QBO specific) and merges new item into old item.

For example:
QBO responds: 
```
{
  Line: [
    {Id: 1, Description: 'This', Amount: 10},
    {Id: 2, Description: 'Or this', Amount: 20},
  ]
}
```

and our update is:
```
{
  Line: [
    {Id: 1, Description: 'Noooo'}
  ]
}
```

then resulting payload will be:
```
{
  Line: [
    {Id: 1, Description: 'Noooo', Amount: 10}
  ]
}
```

This PR doesnt handle arrays of arrays with hashes `[ [{}], [{}, {}] ]`, if we will need it, we can do that later.

---
Note 1: `merge_into` is being moved to QBO as its ledger specific in Ryans serializer PR.
Note 2: Some line items starts with ID: 1 and some starts with ID: 0. Just sayin.
