### PR TITLE
Turns out that the production URL should not be prefixed with app

### DIFF
--- a/lib/ledger_sync/adaptors/quickbooks_online/adaptor.rb
+++ b/lib/ledger_sync/adaptors/quickbooks_online/adaptor.rb
@@ -108,7 +108,7 @@ module LedgerSync
         end
 
         def url_for(resource:)
-          base_url = test ? 'https://app.sandbox.qbo.intuit.com/app' : 'https://app.qbo.intuit.com/app'
+          base_url = test ? 'https://app.sandbox.qbo.intuit.com/app' : 'https://qbo.intuit.com/app'
           resource_path = case resource
                           when LedgerSync::Account
                             "/register?accountId=#{resource.ledger_id}"


### PR DESCRIPTION
Your domain is unique and the redirect is not preserved