### PR TITLE
Add NetSuite ops for currencies

### DIFF
--- a/lib/ledger_sync.rb
+++ b/lib/ledger_sync.rb
@@ -57,22 +57,7 @@ require 'ledger_sync/adaptors/request'
 
 # Resources (resources are registerd below)
 require 'ledger_sync/resource' # Template class
-require 'ledger_sync/resources/ledger_class'
-require 'ledger_sync/resources/department'
-require 'ledger_sync/resources/account'
-require 'ledger_sync/resources/subsidiary'
-require 'ledger_sync/resources/customer'
-require 'ledger_sync/resources/vendor'
-require 'ledger_sync/resources/payment'
-require 'ledger_sync/resources/expense_line_item'
-require 'ledger_sync/resources/expense'
-require 'ledger_sync/resources/deposit_line_item'
-require 'ledger_sync/resources/deposit'
-require 'ledger_sync/resources/transfer'
-require 'ledger_sync/resources/bill_line_item'
-require 'ledger_sync/resources/bill'
-require 'ledger_sync/resources/journal_entry_line_item'
-require 'ledger_sync/resources/journal_entry'
+Gem.find_files('ledger_sync/resources/**/*.rb').each { |path| require path }
 
 module LedgerSync
   @log_level = nil
@@ -140,6 +125,7 @@ Gem.find_files('ledger_sync/adaptors/**/config.rb').each { |path| require path }
 # Register Resources
 LedgerSync.register_resource(resource: LedgerSync::LedgerClass)
 LedgerSync.register_resource(resource: LedgerSync::Department)
+LedgerSync.register_resource(resource: LedgerSync::Currency)
 LedgerSync.register_resource(resource: LedgerSync::Account)
 LedgerSync.register_resource(resource: LedgerSync::Customer)
 LedgerSync.register_resource(resource: LedgerSync::Vendor)

--- a/lib/ledger_sync/adaptors/netsuite/currency/deledger_serializer.rb
+++ b/lib/ledger_sync/adaptors/netsuite/currency/deledger_serializer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module LedgerSync
+  module Adaptors
+    module NetSuite
+      module Currency
+        class LedgerDeserializer < NetSuite::LedgerSerializer
+          api_resource_type :currency
+
+          attribute ledger_attribute: :id,
+                    resource_attribute: :ledger_id
+
+          attribute ledger_attribute: :name,
+                    resource_attribute: :name
+
+          attribute ledger_attribute: :externalid,
+                    resource_attribute: :external_id
+
+          attribute ledger_attribute: :symbol,
+                    resource_attribute: :symbol
+
+          attribute ledger_attribute: :exchangerate,
+                    resource_attribute: :exchange_rate
+        end
+      end
+    end
+  end
+end

--- a/lib/ledger_sync/adaptors/netsuite/currency/ledger_serializer.rb
+++ b/lib/ledger_sync/adaptors/netsuite/currency/ledger_serializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module LedgerSync
+  module Adaptors
+    module NetSuite
+      module Currency
+        class LedgerSerializer < NetSuite::LedgerSerializer
+          api_resource_type :currency
+
+          attribute ledger_attribute: :name,
+                    resource_attribute: :name
+
+          attribute ledger_attribute: :externalid,
+                    resource_attribute: :external_id
+
+          attribute ledger_attribute: :symbol,
+                    resource_attribute: :symbol
+
+          attribute ledger_attribute: :exchangerate,
+                    resource_attribute: :exchange_rate
+        end
+      end
+    end
+  end
+end

--- a/lib/ledger_sync/adaptors/netsuite/currency/operations/create.rb
+++ b/lib/ledger_sync/adaptors/netsuite/currency/operations/create.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# require_relative '../../operation/create'
+
+module LedgerSync
+  module Adaptors
+    module NetSuite
+      module Currency
+        module Operations
+          class Create < NetSuite::Operation::Create
+            class Contract < LedgerSync::Adaptors::Contract
+              params do
+                required(:external_id).maybe(:string)
+                required(:ledger_id).value(:nil)
+                required(:exchange_rate).filled(:float)
+                required(:name).filled(:string)
+                required(:symbol).filled(:string)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ledger_sync/adaptors/netsuite/currency/operations/delete.rb
+++ b/lib/ledger_sync/adaptors/netsuite/currency/operations/delete.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module LedgerSync
+  module Adaptors
+    module NetSuite
+      module Currency
+        module Operations
+          class Delete < NetSuite::Operation::Delete
+            class Contract < LedgerSync::Adaptors::Contract
+              params do
+                required(:external_id).maybe(:string)
+                required(:ledger_id).filled(:string)
+                required(:exchange_rate).maybe(:float)
+                required(:name).maybe(:string)
+                required(:symbol).maybe(:string)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ledger_sync/adaptors/netsuite/currency/operations/find.rb
+++ b/lib/ledger_sync/adaptors/netsuite/currency/operations/find.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module LedgerSync
+  module Adaptors
+    module NetSuite
+      module Currency
+        module Operations
+          class Find < NetSuite::Operation::Find
+            class Contract < LedgerSync::Adaptors::Contract
+              params do
+                required(:external_id).maybe(:string)
+                required(:ledger_id).filled(:string)
+                required(:name).maybe(:string)
+                required(:symbol).maybe(:string)
+                required(:exchange_rate).maybe(:float)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ledger_sync/adaptors/netsuite/currency/operations/update.rb
+++ b/lib/ledger_sync/adaptors/netsuite/currency/operations/update.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module LedgerSync
+  module Adaptors
+    module NetSuite
+      module Currency
+        module Operations
+          class Update < NetSuite::Operation::Update
+            class Contract < LedgerSync::Adaptors::Contract
+              params do
+                required(:external_id).maybe(:string)
+                required(:ledger_id).filled(:string)
+                required(:exchange_rate).maybe(:float)
+                required(:name).filled(:string)
+                required(:symbol).filled(:string)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ledger_sync/resources/bill.rb
+++ b/lib/ledger_sync/resources/bill.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+require_relative 'account'
+require_relative 'bill_line_item'
+require_relative 'vendor'
+
 module LedgerSync
   class Bill < LedgerSync::Resource
     attribute :currency, type: Type::String
@@ -12,7 +18,7 @@ module LedgerSync
     references_many :line_items, to: BillLineItem
 
     def name
-      "Bill: #{transaction_date.to_s}"
+      "Bill: #{transaction_date}"
     end
   end
 end

--- a/lib/ledger_sync/resources/bill_line_item.rb
+++ b/lib/ledger_sync/resources/bill_line_item.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'account'
+
 module LedgerSync
   class BillLineItem < LedgerSync::Resource
     references_one :account, to: Account

--- a/lib/ledger_sync/resources/currency.rb
+++ b/lib/ledger_sync/resources/currency.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module LedgerSync
+  class Currency < LedgerSync::Resource
+    attribute :exchange_rate, type: Type::Float
+    attribute :name, type: Type::String
+    attribute :symbol, type: Type::String
+  end
+end

--- a/lib/ledger_sync/resources/customer.rb
+++ b/lib/ledger_sync/resources/customer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'subsidiary'
+
 module LedgerSync
   class Customer < LedgerSync::Resource
     attribute :email, type: Type::String

--- a/lib/ledger_sync/resources/department.rb
+++ b/lib/ledger_sync/resources/department.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'department'
+
 module LedgerSync
   class Department < LedgerSync::Resource
     attribute :name, type: Type::String

--- a/lib/ledger_sync/resources/deposit.rb
+++ b/lib/ledger_sync/resources/deposit.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+require_relative 'account'
+require_relative 'department'
+require_relative 'deposit_line_item'
+
 module LedgerSync
   class Deposit < LedgerSync::Resource
     attribute :currency, type: Type::String

--- a/lib/ledger_sync/resources/deposit_line_item.rb
+++ b/lib/ledger_sync/resources/deposit_line_item.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+require_relative 'account'
+require_relative 'customer'
+require_relative 'vendor'
+
 module LedgerSync
   class DepositLineItem < LedgerSync::Resource
     references_one :account, to: Account

--- a/lib/ledger_sync/resources/expense.rb
+++ b/lib/ledger_sync/resources/expense.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require_relative 'account'
+require_relative 'customer'
+require_relative 'expense_line_item'
+require_relative 'vendor'
+
 module LedgerSync
   class Expense < LedgerSync::Resource
     attribute :currency, type: Type::String

--- a/lib/ledger_sync/resources/expense_line_item.rb
+++ b/lib/ledger_sync/resources/expense_line_item.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'account'
+
 module LedgerSync
   class ExpenseLineItem < LedgerSync::Resource
     references_one :account, to: Account

--- a/lib/ledger_sync/resources/journal_entry.rb
+++ b/lib/ledger_sync/resources/journal_entry.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require_relative 'journal_entry_line_item'
+
 module LedgerSync
   class JournalEntry < LedgerSync::Resource
     attribute :currency, type: Type::String
@@ -8,7 +12,7 @@ module LedgerSync
     references_many :line_items, to: JournalEntryLineItem
 
     def name
-      "JournalEntry: #{transaction_date.to_s}"
+      "JournalEntry: #{transaction_date}"
     end
   end
 end

--- a/lib/ledger_sync/resources/journal_entry_line_item.rb
+++ b/lib/ledger_sync/resources/journal_entry_line_item.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require_relative 'account'
+
 module LedgerSync
   class JournalEntryLineItem < LedgerSync::Resource
     references_one :account, to: Account

--- a/lib/ledger_sync/resources/ledger_class.rb
+++ b/lib/ledger_sync/resources/ledger_class.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'ledger_class'
+
 module LedgerSync
   class LedgerClass < LedgerSync::Resource
     attribute :name, type: Type::String

--- a/lib/ledger_sync/resources/payment.rb
+++ b/lib/ledger_sync/resources/payment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'customer'
+
 module LedgerSync
   class Payment < LedgerSync::Resource
     attribute :amount, type: Type::Integer

--- a/lib/ledger_sync/resources/transfer.rb
+++ b/lib/ledger_sync/resources/transfer.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require_relative 'account'
+
 module LedgerSync
   class Transfer < LedgerSync::Resource
     attribute :currency, type: Type::String

--- a/lib/ledger_sync/resources/vendor.rb
+++ b/lib/ledger_sync/resources/vendor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'subsidiary'
+
 module LedgerSync
   class Vendor < LedgerSync::Resource
     attribute :company_name, type: Type::String

--- a/qa/netsuite/currency_spec.rb
+++ b/qa/netsuite/currency_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe LedgerSync::Adaptors::NetSuite::Currency, adaptor: :netsuite do
+  let(:adaptor) { netsuite_adaptor }
+  let(:attribute_updates) do
+    {
+      name: "QA UPDATE #{test_run_id}"
+    }
+  end
+  let(:record) { :currency }
+  let(:resource) do
+    FactoryBot.create(:currency)
+  end
+
+  it_behaves_like 'a full netsuite resource'
+end

--- a/spec/adaptors/netsuite/currency/operations/create_spec.rb
+++ b/spec/adaptors/netsuite/currency/operations/create_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+support :input_helpers,
+        :operation_shared_examples,
+        :netsuite_helpers
+
+RSpec.describe LedgerSync::Adaptors::NetSuite::Currency::Operations::Create do
+  include InputHelpers
+  include NetSuiteHelpers
+
+  let(:resource) { FactoryBot.create(:currency) }
+  let(:adaptor) { netsuite_adaptor }
+
+  it_behaves_like 'an operation'
+  it_behaves_like 'a successful operation',
+                  stubs: %i[
+                    stub_currency_find
+                    stub_currency_create
+                  ]
+end

--- a/spec/adaptors/netsuite/currency/operations/delete_spec.rb
+++ b/spec/adaptors/netsuite/currency/operations/delete_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+support :input_helpers,
+        :operation_shared_examples,
+        :netsuite_helpers
+
+RSpec.describe LedgerSync::Adaptors::NetSuite::Currency::Operations::Delete do
+  include InputHelpers
+  include NetSuiteHelpers
+
+  let(:resource) { FactoryBot.create(:currency, ledger_id: 2) }
+  let(:adaptor) { netsuite_adaptor }
+
+  it_behaves_like 'an operation'
+  it_behaves_like 'a successful operation', stubs: :stub_currency_delete
+end

--- a/spec/adaptors/netsuite/currency/operations/find_spec.rb
+++ b/spec/adaptors/netsuite/currency/operations/find_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+support :input_helpers,
+        :operation_shared_examples,
+        :netsuite_helpers
+
+RSpec.describe LedgerSync::Adaptors::NetSuite::Currency::Operations::Find do
+  include InputHelpers
+  include NetSuiteHelpers
+
+  let(:resource) { FactoryBot.create(:currency, ledger_id: 2) }
+  let(:adaptor) { netsuite_adaptor }
+
+  it_behaves_like 'an operation'
+  it_behaves_like 'a successful operation', stubs: :stub_currency_find
+end

--- a/spec/adaptors/netsuite/currency/operations/update_spec.rb
+++ b/spec/adaptors/netsuite/currency/operations/update_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+support :input_helpers,
+        :operation_shared_examples,
+        :netsuite_helpers
+
+RSpec.describe LedgerSync::Adaptors::NetSuite::Currency::Operations::Update do
+  include InputHelpers
+  include NetSuiteHelpers
+
+  let(:resource) { FactoryBot.create(:currency, ledger_id: 2) }
+  let(:adaptor) { netsuite_adaptor }
+
+  it_behaves_like 'an operation'
+  it_behaves_like 'a successful operation',
+                  stubs: %i[
+                    stub_currency_find
+                    stub_currency_update
+                  ]
+end

--- a/spec/factories/currencies.rb
+++ b/spec/factories/currencies.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :currency, class: LedgerSync::Currency do
+    exchange_rate { 1.5 }
+    sequence(:name) { |n| "Test Currency #{rand_id}-#{n}" }
+    symbol { 'ZZZ' }
+  end
+end

--- a/spec/resources/expense_spec.rb
+++ b/spec/resources/expense_spec.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe LedgerSync::Expense do
-
   describe '#entity' do
     it do
       expect { described_class.new(entity: LedgerSync::Customer.new) }.not_to raise_error

--- a/spec/support/netsuite_helpers.rb
+++ b/spec/support/netsuite_helpers.rb
@@ -17,6 +17,34 @@ module NetSuiteHelpers
     }.merge(override)
   end
 
+  def currency_json(**overrides)
+    {
+      "links": [
+          {
+              "rel": "self",
+              "href": "https://5743578-sb1.suitetalk.api.netsuite.com/rest/platform/v1/record/currency/2"
+          }
+      ],
+      "currencyPrecision": 2,
+      "displaySymbol": "£",
+      "exchangeRate": 1.3037,
+      "id": "2",
+      "includeInFxRateUpdates": true,
+      "isBaseCurrency": false,
+      "isInactive": false,
+      "name": "British pound",
+      "overrideCurrencyFormat": false,
+      "symbol": "GBP",
+      "symbolPlacement": "1"
+    }.merge(overrides).to_json
+  end
+
+  def currency_url(id: nil)
+    ret = 'https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/currency'
+    ret += "/#{id}" if id.present?
+    ret
+  end
+
   def customer_json
     '{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/customer/1137"}],"addressbook":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/customer/1137/addressbook"}]},"alcoholRecipientType":"CONSUMER","balance":0.0,"companyName":"Company 1575890547","creditCards":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/customer/1137/creditCards"}]},"creditholdoverride":"AUTO","currency":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/currency/1"}],"id":"1","refName":"USA"},"currencyList":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/customer/1137/currencyList"}]},"custentity_atlas_help_entity_lp_ref":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/customrecord_atlas_help_reference/4"}],"id":"4","refName":"Order to Cash"},"custentity_esc_last_modified_date":"2019-12-09","customForm":"30","dateCreated":"2019-12-09T11:22:00Z","depositbalance":0.0,"email":"customer@company.com","emailPreference":"DEFAULT","emailTransactions":false,"entityId":"Company 1575890547","entityStatus":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/customerstatus/13"}],"id":"13","refName":"CUSTOMER-Closed Won"},"faxTransactions":false,"grouppricing":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/customer/1137/grouppricing"}]},"id":"1137","isBudgetApproved":false,"isinactive":false,"isPerson":false,"itempricing":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/customer/1137/itempricing"}]},"language":"en_US","lastModifiedDate":"2019-12-09T11:22:00Z","overduebalance":0.0,"printTransactions":false,"receivablesaccount":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/account/-10"}],"id":"-10","refName":"Use System Preference"},"shipComplete":false,"shippingCarrier":"nonups","subsidiary":{"links":[{"rel":"self","href":"https://netsuite_account_id.suitetalk.api.netsuite.com/rest/platform/v1/record/subsidiary/2"}],"id":"2","refName":"Modern Treasury"},"taxable":false,"unbilledorders":0.0}'
   end
@@ -36,6 +64,58 @@ module NetSuiteHelpers
       token_id: env ? ENV.fetch('NETSUITE_TOKEN_ID', 'NETSUITE_TOKEN_ID') : 'NETSUITE_TOKEN_ID',
       token_secret: env ? ENV.fetch('NETSUITE_TOKEN_SECRET', 'NETSUITE_TOKEN_SECRET') : 'NETSUITE_TOKEN_SECRET'
     )
+  end
+
+  def stub_currency_create
+    stub_request(:post, currency_url)
+      .with(
+        headers: authorized_headers(write: true)
+      )
+      .to_return(
+        status: 200,
+        body: '',
+        headers: {
+          'Location': currency_url(id: 2)
+        }
+      )
+  end
+
+  def stub_currency_delete
+    stub_request(:delete, currency_url(id: 2))
+      .with(
+        headers: authorized_headers
+      )
+      .to_return(
+        status: 204,
+        body: '',
+        headers: {}
+      )
+  end
+
+  def stub_currency_find
+    stub_request(:get, currency_url(id: 2))
+      .with(
+        headers: authorized_headers
+      )
+      .to_return(
+        status: 200,
+        body: currency_json,
+        headers: {}
+      )
+  end
+
+  def stub_currency_update
+    stub_request(:patch, currency_url(id: 2))
+      .with(
+        headers: authorized_headers(write: true)
+      )
+      .to_return(
+        status: 200,
+        body: '',
+        headers: {
+          'Location': currency_url(id: 2)
+        }
+      )
   end
 
   def stub_customer_create


### PR DESCRIPTION
NetSuite has a currency object, which is needed for `Account` and other objects as a reference. (a.k.a. you can't just say `"USD"`).

Needed for: #132 