### PR TITLE
Add options to disable de/serialize for any attribute

### DIFF
--- a/lib/ledger_sync/adaptors/ledger_serializer.rb
+++ b/lib/ledger_sync/adaptors/ledger_serializer.rb
@@ -28,7 +28,7 @@ module LedgerSync
         deserialize_into = resource.dup # Do not overwrite values in the resource
         hash = Util::HashHelpers.deep_stringify_keys(hash)
 
-        self.class.attributes.deserialize_attributes.each do |ledger_serializer_attribute|
+        self.class.attributes.deserializable_attributes.each do |ledger_serializer_attribute|
           next unless ledger_serializer_attribute.resource_attribute?
 
           value = attribute_value_from_ledger(
@@ -49,7 +49,7 @@ module LedgerSync
       def to_ledger_hash(only_changes: false)
         ret = {}
 
-        self.class.attributes.serialize_attributes.each do |ledger_serializer_attribute|
+        self.class.attributes.serializable_attributes.each do |ledger_serializer_attribute|
           next if only_changes && !resource.attribute_changed?(ledger_serializer_attribute.resource_attribute)
 
           ret = Util::HashHelpers.deep_merge(

--- a/lib/ledger_sync/adaptors/ledger_serializer.rb
+++ b/lib/ledger_sync/adaptors/ledger_serializer.rb
@@ -12,9 +12,9 @@ module LedgerSync
 
       attr_reader :resource
 
-      def initialize(resource:)
+      def initialize(ensure_inferred_resource_class: true, resource:)
         @resource = resource
-        ensure_inferred_resource_class!
+        ensure_inferred_resource_class! if ensure_inferred_resource_class
       end
 
       def attribute_value_from_ledger(hash:, ledger_serializer_attribute:, resource:)
@@ -28,7 +28,7 @@ module LedgerSync
         deserialize_into = resource.dup # Do not overwrite values in the resource
         hash = Util::HashHelpers.deep_stringify_keys(hash)
 
-        self.class.attributes.each do |ledger_serializer_attribute|
+        self.class.attributes.deserialize_attributes.each do |ledger_serializer_attribute|
           next unless ledger_serializer_attribute.resource_attribute?
 
           value = attribute_value_from_ledger(
@@ -49,7 +49,7 @@ module LedgerSync
       def to_ledger_hash(only_changes: false)
         ret = {}
 
-        self.class.attributes.each do |ledger_serializer_attribute|
+        self.class.attributes.serialize_attributes.each do |ledger_serializer_attribute|
           next if only_changes && !resource.attribute_changed?(ledger_serializer_attribute.resource_attribute)
 
           ret = Util::HashHelpers.deep_merge(
@@ -61,11 +61,20 @@ module LedgerSync
         ret
       end
 
-      def self.attribute(ledger_attribute:, resource_attribute: nil, type: LedgerSerializerType::ValueType, &block)
+      def self.attribute(
+        deserialize: true,
+        ledger_attribute:,
+        resource_attribute: nil,
+        serialize: true,
+        type: LedgerSerializerType::ValueType,
+        &block
+      )
         _attribute(
           block: (block if block_given?),
+          deserialize: deserialize,
           ledger_attribute: ledger_attribute,
           resource_attribute: resource_attribute,
+          serialize: serialize,
           type: type
         )
       end
@@ -98,13 +107,25 @@ module LedgerSync
         )
       end
 
-      private_class_method def self._build_attribute(block: nil, id: false, ledger_attribute:, resource_attribute: nil, resource_class: nil, serializer: nil, type: LedgerSerializerType::ValueType)
+      private_class_method def self._build_attribute(
+        block: nil,
+        deserialize: true,
+        id: false,
+        ledger_attribute:,
+        resource_attribute: nil,
+        resource_class: nil,
+        serialize: true,
+        serializer: nil,
+        type: LedgerSerializerType::ValueType
+      )
         LedgerSerializerAttribute.new(
           id: id,
           block: block,
+          deserialize: deserialize,
           ledger_attribute: ledger_attribute,
           resource_attribute: resource_attribute,
           resource_class: resource_class,
+          serialize: serialize,
           serializer: serializer,
           type: type
         )

--- a/lib/ledger_sync/adaptors/ledger_serializer_attribute.rb
+++ b/lib/ledger_sync/adaptors/ledger_serializer_attribute.rb
@@ -7,27 +7,45 @@ module LedgerSync
   module Adaptors
     class LedgerSerializerAttribute
       attr_reader :block,
+                  :deserialize,
                   :id,
                   :ledger_attribute,
                   :resource_attribute,
                   :resource_class,
+                  :serialize,
                   :serializer,
                   :type
 
-      def initialize(block: nil, id: false, ledger_attribute:, resource_attribute: nil, resource_class: nil, serializer: nil, type: LedgerSerializerType::ValueType)
+      def initialize(
+        block: nil,
+        deserialize: true,
+        id: false,
+        ledger_attribute:,
+        resource_attribute: nil,
+        resource_class: nil,
+        serialize: true,
+        serializer: nil,
+        type: LedgerSerializerType::ValueType
+      )
         raise 'block and resource_attribute cannot both be present' unless block.nil? || resource_attribute.nil?
 
         @block = block
+        @deserialize = deserialize
         @id = id
         @ledger_attribute = ledger_attribute.to_s
         @resource_attribute = resource_attribute.to_s
         @resource_class = resource_class
+        @serialize = serialize
         @serializer = serializer
         @type = type.new
       end
 
       def block_value_for(resource:)
         block.call(resource)
+      end
+
+      def deserialize?
+        deserialize
       end
 
       # Make nested/dot calls (e.g. `vendor.ledger_id`)
@@ -69,6 +87,10 @@ module LedgerSync
 
       def resource_attribute_dot_parts
         @resource_attribute_dot_parts ||= resource_attribute.split('.')
+      end
+
+      def serialize?
+        serialize
       end
 
       def value_from_local(resource:)

--- a/lib/ledger_sync/adaptors/ledger_serializer_attribute_set.rb
+++ b/lib/ledger_sync/adaptors/ledger_serializer_attribute_set.rb
@@ -4,9 +4,11 @@ module LedgerSync
   module Adaptors
     class LedgerSerializerAttributeSet
       attr_reader :attributes,
+                  :deserialize_attributes,
                   :id_attribute,
                   :ledger_attribute_keyed_hash,
                   :resource_attribute_keyed_hash,
+                  :serialize_attributes,
                   :serializer_class
 
       delegate  :[],
@@ -17,8 +19,10 @@ module LedgerSync
 
       def initialize(serializer_class:)
         @attributes = []
+        @deserialize_attributes = []
         @ledger_attribute_keyed_hash = {}
         @resource_attribute_keyed_hash = {}
+        @serialize_attributes = []
         @serializer_class = serializer_class
       end
 
@@ -36,6 +40,9 @@ module LedgerSync
 
           resource_attribute_keyed_hash[attribute.resource_attribute.to_s] = attribute
         end
+
+        serialize_attributes << attribute if attribute.serialize?
+        deserialize_attributes << attribute if attribute.deserialize?
 
         # TODO: Can make this validate something like `expense.vendor.id`
         # raise "#{resource_attribute} is not an attribute of the resource #{_inferred_resource_class}" if !resource_attribute.nil? && !_inferred_resource_class.serialize_attribute?(resource_attribute)

--- a/lib/ledger_sync/adaptors/ledger_serializer_attribute_set.rb
+++ b/lib/ledger_sync/adaptors/ledger_serializer_attribute_set.rb
@@ -4,11 +4,11 @@ module LedgerSync
   module Adaptors
     class LedgerSerializerAttributeSet
       attr_reader :attributes,
-                  :deserialize_attributes,
+                  :deserializable_attributes,
                   :id_attribute,
                   :ledger_attribute_keyed_hash,
                   :resource_attribute_keyed_hash,
-                  :serialize_attributes,
+                  :serializable_attributes,
                   :serializer_class
 
       delegate  :[],
@@ -19,10 +19,10 @@ module LedgerSync
 
       def initialize(serializer_class:)
         @attributes = []
-        @deserialize_attributes = []
+        @deserializable_attributes = []
         @ledger_attribute_keyed_hash = {}
         @resource_attribute_keyed_hash = {}
-        @serialize_attributes = []
+        @serializable_attributes = []
         @serializer_class = serializer_class
       end
 
@@ -41,8 +41,8 @@ module LedgerSync
           resource_attribute_keyed_hash[attribute.resource_attribute.to_s] = attribute
         end
 
-        serialize_attributes << attribute if attribute.serialize?
-        deserialize_attributes << attribute if attribute.deserialize?
+        serializable_attributes << attribute if attribute.serialize?
+        deserializable_attributes << attribute if attribute.deserialize?
 
         # TODO: Can make this validate something like `expense.vendor.id`
         # raise "#{resource_attribute} is not an attribute of the resource #{_inferred_resource_class}" if !resource_attribute.nil? && !_inferred_resource_class.serialize_attribute?(resource_attribute)

--- a/lib/ledger_sync/adaptors/quickbooks_online/ledger_serializer.rb
+++ b/lib/ledger_sync/adaptors/quickbooks_online/ledger_serializer.rb
@@ -25,7 +25,7 @@ module LedgerSync
         def merge_resources_for_full_update(hash:, ledger_resource:)
           merged_resource = resource.dup
 
-          self.class.attributes.each do |ledger_serializer_attribute|
+          self.class.attributes.deserialize_attributes.each do |ledger_serializer_attribute|
             next unless ledger_serializer_attribute.references_many?
 
             resources_from_ledger = attribute_value_from_ledger(

--- a/lib/ledger_sync/adaptors/quickbooks_online/ledger_serializer.rb
+++ b/lib/ledger_sync/adaptors/quickbooks_online/ledger_serializer.rb
@@ -25,7 +25,7 @@ module LedgerSync
         def merge_resources_for_full_update(hash:, ledger_resource:)
           merged_resource = resource.dup
 
-          self.class.attributes.deserialize_attributes.each do |ledger_serializer_attribute|
+          self.class.attributes.deserializable_attributes.each do |ledger_serializer_attribute|
             next unless ledger_serializer_attribute.references_many?
 
             resources_from_ledger = attribute_value_from_ledger(

--- a/spec/adaptors/ledger_serializer_spec.rb
+++ b/spec/adaptors/ledger_serializer_spec.rb
@@ -7,11 +7,68 @@ support :ledger_serializer_helpers
 RSpec.describe LedgerSync::Adaptors::LedgerSerializer do
   include LedgerSerializerHelpers
 
+  let(:test_serializer_class) do
+    Class.new(LedgerSync::Adaptors::LedgerSerializer) do
+      attribute ledger_attribute: :name,
+                resource_attribute: :name,
+                serialize: false,
+                deserialize: true
+      attribute ledger_attribute: :phone_number,
+                resource_attribute: :phone_number,
+                serialize: true,
+                deserialize: false
+
+      # Default true
+      attribute ledger_attribute: :email,
+                resource_attribute: :email
+    end
+  end
+
+  let(:test_serializer) do
+    test_serializer_class.new(
+      ensure_inferred_resource_class: false,
+      resource: test_resource
+    )
+  end
+
+  let(:test_resource) do
+    LedgerSync::Customer.new(
+      name: 'test_name',
+      phone_number: 'test_phone',
+      email: 'test_email'
+    )
+  end
+
   it { expect(described_class).to respond_to(:attribute) }
   it { expect(described_class).to respond_to(:references_many) }
   it { expect(described_class).to respond_to(:id) }
 
+  describe '#deserialize' do
+    it do
+      h = {
+        name: 'test_name',
+        phone_number: 'test_phone',
+        email: 'test_email'
+      }
+      test_serializer = test_serializer_class.new(
+        ensure_inferred_resource_class: false,
+        resource: LedgerSync::Customer.new
+      )
+      resource = LedgerSync::Customer.new(**h.except(:phone_number))
+      deserialized_resource = test_serializer.deserialize(hash: h)
+      expect(deserialized_resource).to eq(resource)
+    end
+  end
+
   describe '#to_ledger_hash' do
+    it do
+      h = {
+        'phone_number' => 'test_phone',
+        'email' => 'test_email'
+      }
+      expect(test_serializer.to_ledger_hash).to eq(h)
+    end
+
     it do
       resource = LedgerSync::Customer.new
       serializer = LedgerSync::Adaptors::QuickBooksOnline::Customer::LedgerSerializer.new(resource: resource)


### PR DESCRIPTION
Fix #121 

You can now disable serializing or deserializing specific attributes.  This will prevent us from rewriting serializers yet.