### PR TITLE
Add dashboard helper url for LedgerClass

### DIFF
--- a/lib/ledger_sync/adaptors/quickbooks_online/dashboard_url_helper.rb
+++ b/lib/ledger_sync/adaptors/quickbooks_online/dashboard_url_helper.rb
@@ -33,6 +33,8 @@ module LedgerSync
             "/expense?txnId=#{resource.ledger_id}"
           when LedgerSync::JournalEntry
             "/journal?txnId=#{resource.ledger_id}"
+          when LedgerSync::LedgerClass
+            "/class"
           when LedgerSync::Payment
             "/recvpayment?txnId=#{resource.ledger_id}"
           when LedgerSync::Transfer


### PR DESCRIPTION
It seems that there isn't a detailed view for an individual class so the URL doesn't include an ID