### PR TITLE
Use old union operator 

### DIFF
--- a/lib/ledger_sync/util/mixins/delegate_iterable_methods_mixin.rb
+++ b/lib/ledger_sync/util/mixins/delegate_iterable_methods_mixin.rb
@@ -15,16 +15,14 @@ module LedgerSync
             map
           ].freeze
 
-          ARRAY_METHODS = SHARED_METHODS.union(%i[]).freeze
+          ARRAY_METHODS = (SHARED_METHODS | %i[]).freeze
 
-          HASH_METHODS = SHARED_METHODS.union(
-            %i[
-              each_value
-              key?
-              keys
-              values
-            ]
-          ).freeze
+          HASH_METHODS = (SHARED_METHODS | %i[
+            each_value
+            key?
+            keys
+            values
+          ]).freeze
 
           def delegate_array_methods_to(delegate_to)
             delegate(*ARRAY_METHODS, to: delegate_to)


### PR DESCRIPTION
This PR changes us back to using the old union operator `|` instead of the newer [Array.union](https://apidock.com/ruby/Array/union). The newer method is only available in ruby `2.6.3` and up which limits the compatibility.