### PR TITLE
Cast NS account_types from camel case to snake case

### DIFF
--- a/lib/ledger_sync/ledgers/netsuite/account/searcher_deserializer.rb
+++ b/lib/ledger_sync/ledgers/netsuite/account/searcher_deserializer.rb
@@ -14,7 +14,8 @@ module LedgerSync
                     hash_attribute: :acctnumber
 
           attribute :account_type,
-                    hash_attribute: :accttype
+                    hash_attribute: :accttype,
+                    type: LedgerSync::Serialization::Type::CamelToSnakeStringType.new
 
           attribute :description
 

--- a/lib/ledger_sync/serialization/type/camel_to_snake_string_type.rb
+++ b/lib/ledger_sync/serialization/type/camel_to_snake_string_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module LedgerSync
+  class Serialization
+    module Type
+      class CamelToSnakeStringType < LedgerSync::Type::Value
+        def cast_value(args = {})
+          value = args.fetch(:value)
+
+          return if value.nil?
+          value.snakecase
+        end
+      end
+    end
+  end
+end

--- a/spec/ledgers/netsuite/account/searcher_deserializer_spec.rb
+++ b/spec/ledgers/netsuite/account/searcher_deserializer_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe LedgerSync::Ledgers::NetSuite::Account::SearcherDeserializer do
   let(:accountsearchdisplayname) { 'test-accountsearchdisplayname' }
   let(:acctnumber) { '654654' }
-  let(:accttype) { 'test-accttype' }
+  let(:accttype) { 'TestAccttype' }
   let(:isinactive) { 'F' }
   let(:id) { 'acct_1234' }
 
@@ -27,7 +27,7 @@ RSpec.describe LedgerSync::Ledgers::NetSuite::Account::SearcherDeserializer do
       expect(deserialized_resource.ledger_id).to eq(id)
       expect(deserialized_resource.name).to eq(accountsearchdisplayname)
       expect(deserialized_resource.number).to eq(acctnumber)
-      expect(deserialized_resource.account_type).to eq(accttype)
+      expect(deserialized_resource.account_type).to eq(accttype.snakecase)
       expect(deserialized_resource.active).to be_truthy
     end
   end


### PR DESCRIPTION
Casting NS account_type values to snake case in order to be consistent across ledgers.