### PR TITLE
Conditionally include references in serializers

### DIFF
--- a/lib/ledger_sync/ledgers/netsuite/check/serializer.rb
+++ b/lib/ledger_sync/ledgers/netsuite/check/serializer.rb
@@ -11,13 +11,13 @@ module LedgerSync
           attribute :trandate
 
           references_one :account,
-                         serializer: Reference::Serializer
+                         serializer: Reference::Serializer, if: :account_present?
 
           references_one :department,
-                         serializer: Reference::Serializer
+                         serializer: Reference::Serializer, if: :department_present?
 
           references_one :currency,
-                         serializer: Reference::Serializer
+                         serializer: Reference::Serializer, if: :currency_present?
 
           references_one :entity,
                          serializer: Reference::Serializer
@@ -25,6 +25,24 @@ module LedgerSync
           references_many 'expense.items',
                           resource_attribute: :line_items,
                           serializer: CheckLineItem::Serializer
+
+          def account_present?(args = {})
+            resource = args.fetch(:resource)
+
+            resource.account.present?
+          end
+
+          def department_present?(args = {})
+            resource = args.fetch(:resource)
+
+            resource.department.present?
+          end
+
+          def currency_present?(args = {})
+            resource = args.fetch(:resource)
+
+            resource.currency.present?
+          end
         end
       end
     end

--- a/lib/ledger_sync/ledgers/netsuite/journal_entry/serializer.rb
+++ b/lib/ledger_sync/ledgers/netsuite/journal_entry/serializer.rb
@@ -15,7 +15,7 @@ module LedgerSync
           attribute :tranId
 
           references_one :currency,
-                         serializer: Reference::Serializer
+                         serializer: Reference::Serializer, if: :currency_present?
 
           references_one :subsidiary,
                          serializer: Reference::Serializer
@@ -24,6 +24,11 @@ module LedgerSync
                           resource_attribute: :line_items,
                           serializer: JournalEntryLineItem::Serializer
 
+          def currency_present?(args = {})
+            resource = args.fetch(:resource)
+
+            resource.currency.present?
+          end
         end
       end
     end


### PR DESCRIPTION
NetSuite returns 4xx errors if we pass null values for some references in the payload. This PR uses #224 to not include these references if the are `nil`.