### PR TITLE
Fix classification - ledger_class mapping

### DIFF
--- a/lib/ledger_sync/ledgers/netsuite/check_line_item/deserializer.rb
+++ b/lib/ledger_sync/ledgers/netsuite/check_line_item/deserializer.rb
@@ -8,7 +8,8 @@ module LedgerSync
           attribute :amount
           attribute :memo
           references_one :account
-          references_one :ledger_class
+          references_one :ledger_class,
+                         hash_attribute: 'class'
           references_one :department
         end
       end

--- a/lib/ledger_sync/ledgers/netsuite/check_line_item/serializer.rb
+++ b/lib/ledger_sync/ledgers/netsuite/check_line_item/serializer.rb
@@ -16,7 +16,8 @@ module LedgerSync
           references_one :department,
                          serializer: Reference::Serializer
 
-          references_one :ledger_class,
+          references_one :class,
+                         resource_attribute: :ledger_class,
                          serializer: Reference::Serializer
         end
       end


### PR DESCRIPTION
We call it ledger_class, but in netsuite its classification