### PR TITLE
Move QBO to Reference

### DIFF
--- a/lib/ledger_sync/ledger_configuration_store.rb
+++ b/lib/ledger_sync/ledger_configuration_store.rb
@@ -15,9 +15,7 @@ module LedgerSync
 
     def add_alias(client_key, existing_config)
       if respond_to?(client_key)
-        if send(client_key) != existing_config
-          raise LedgerSync::ConfigurationError, "Alias already taken: #{client_key}"
-        end
+        raise "Alias already taken: #{client_key}" if send(client_key) != existing_config
 
         return
       end

--- a/lib/ledger_sync/ledgers/quickbooks_online/account/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/account/deserializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/deserializer'
+require_relative '../reference/deserializer'
 
 module LedgerSync
   module Ledgers
@@ -34,8 +34,8 @@ module LedgerSync
                     hash_attribute: 'Active'
 
           references_one :currency,
-                         hash_attribute: :CurrencyRef,
-                         deserializer: Currency::Deserializer
+                         hash_attribute: 'CurrencyRef',
+                         deserializer: Reference::Deserializer
         end
       end
     end

--- a/lib/ledger_sync/ledgers/quickbooks_online/account/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/account/serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/serializer'
+require_relative '../reference/serializer'
 
 module LedgerSync
   module Ledgers
@@ -27,9 +27,9 @@ module LedgerSync
           attribute 'Active',
                     resource_attribute: :active
 
-          references_one :CurrencyRef,
+          references_one 'CurrencyRef',
                          resource_attribute: :currency,
-                         serializer: Currency::Serializer
+                         serializer: Reference::Serializer
         end
       end
     end

--- a/lib/ledger_sync/ledgers/quickbooks_online/bill/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/bill/deserializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../bill_line_item/deserializer'
-require_relative '../currency/deserializer'
+require_relative '../reference/deserializer'
 
 module LedgerSync
   module Ledgers
@@ -11,8 +11,8 @@ module LedgerSync
           id
 
           references_one :currency,
-                         hash_attribute: :CurrencyRef,
-                         deserializer: Currency::Deserializer
+                         hash_attribute: 'CurrencyRef',
+                         deserializer: Reference::Deserializer
 
           date :due_date,
                hash_attribute: 'DueDate'
@@ -23,14 +23,17 @@ module LedgerSync
           date :transaction_date,
                hash_attribute: 'TxnDate'
 
-          attribute 'vendor.ledger_id',
-                    hash_attribute: 'VendorRef.value'
+          references_one :vendor,
+                         hash_attribute: 'VendorRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'APAccountRef.value'
+          references_one :account,
+                         hash_attribute: 'APAccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'department.ledger_id',
-                    hash_attribute: 'DepartmentRef.value'
+          references_one :department,
+                         hash_attribute: 'DepartmentRef',
+                         deserializer: Reference::Deserializer
 
           attribute :reference_number,
                     hash_attribute: 'DocNumber'

--- a/lib/ledger_sync/ledgers/quickbooks_online/bill/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/bill/serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../bill_line_item/serializer'
-require_relative '../currency/serializer'
+require_relative '../reference/serializer'
 
 module LedgerSync
   module Ledgers
@@ -10,26 +10,30 @@ module LedgerSync
         class Serializer < QuickBooksOnline::Serializer
           id
 
-          references_one :CurrencyRef,
+          references_one 'CurrencyRef',
                          resource_attribute: :currency,
-                         serializer: Currency::Serializer
+                         serializer: Reference::Serializer
 
           date 'DueDate',
                resource_attribute: :due_date
 
-          attribute 'PrivateNote', resource_attribute: :memo
+          attribute 'PrivateNote',
+                    resource_attribute: :memo
 
           date 'TxnDate',
                resource_attribute: :transaction_date
 
-          attribute 'VendorRef.value',
-                    resource_attribute: 'vendor.ledger_id'
+          references_one 'VendorRef',
+                         resource_attribute: :vendor,
+                         serializer: Reference::Serializer
 
-          attribute 'APAccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'APAccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
-          attribute 'DepartmentRef.value',
-                    resource_attribute: 'department.ledger_id'
+          references_one 'DepartmentRef',
+                         resource_attribute: :department,
+                         serializer: Reference::Serializer
 
           attribute 'DocNumber',
                     resource_attribute: :reference_number

--- a/lib/ledger_sync/ledgers/quickbooks_online/bill_line_item/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/bill_line_item/deserializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/deserializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -7,11 +9,13 @@ module LedgerSync
         class Deserializer < QuickBooksOnline::Deserializer
           id
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'AccountBasedExpenseLineDetail.AccountRef.value'
+          references_one :account,
+                         hash_attribute: 'AccountBasedExpenseLineDetail.AccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'ledger_class.ledger_id',
-                    hash_attribute: 'AccountBasedExpenseLineDetail.ClassRef.value'
+          references_one :ledger_class,
+                         hash_attribute: 'AccountBasedExpenseLineDetail.ClassRef',
+                         deserializer: Reference::Deserializer
 
           amount :amount,
                  hash_attribute: 'Amount'

--- a/lib/ledger_sync/ledgers/quickbooks_online/bill_line_item/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/bill_line_item/serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/serializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -11,11 +13,13 @@ module LedgerSync
             'AccountBasedExpenseLineDetail'
           end
 
-          attribute 'AccountBasedExpenseLineDetail.AccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'AccountBasedExpenseLineDetail.AccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
-          attribute 'AccountBasedExpenseLineDetail.ClassRef.value',
-                    resource_attribute: 'ledger_class.ledger_id'
+          references_one 'AccountBasedExpenseLineDetail.ClassRef',
+                         resource_attribute: :ledger_class,
+                         serializer: Reference::Serializer
 
           amount 'Amount',
                  resource_attribute: :amount

--- a/lib/ledger_sync/ledgers/quickbooks_online/bill_payment/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/bill_payment/deserializer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/deserializer'
-require_relative '../department/deserializer'
+require_relative '../reference/deserializer'
 require_relative '../bill_payment_line_item/deserializer'
 
 module LedgerSync
@@ -15,17 +14,20 @@ module LedgerSync
                  hash_attribute: 'TotalAmt'
 
           references_one :currency,
-                         hash_attribute: :CurrencyRef,
-                         deserializer: Currency::Deserializer
+                         hash_attribute: 'CurrencyRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'vendor.ledger_id',
-                    hash_attribute: 'VendorRef.value'
+          references_one :vendor,
+                         hash_attribute: 'VendorRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'department.ledger_id',
-                    hash_attribute: 'DepartmentRef.value'
+          references_one :account,
+                         hash_attribute: 'APAccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'APAccountRef.value'
+          references_one :department,
+                         hash_attribute: 'DepartmentRef',
+                         deserializer: Reference::Deserializer
 
           attribute :reference_number,
                     hash_attribute: 'DocNumber'
@@ -48,6 +50,14 @@ module LedgerSync
 
           attribute 'bank_account.ledger_id',
                     hash_attribute: 'CheckPayment.BankAccountRef.value'
+
+          references_one :credit_card_account,
+                         hash_attribute: 'CreditCardPayment.CCAccountRef',
+                         deserializer: Reference::Deserializer
+
+          references_one :bank_account,
+                         hash_attribute: 'CheckPayment.BankAccountRef',
+                         deserializer: Reference::Deserializer
 
           references_many :line_items,
                           hash_attribute: 'Line',

--- a/lib/ledger_sync/ledgers/quickbooks_online/bill_payment/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/bill_payment/serializer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/serializer'
-require_relative '../department/serializer'
+require_relative '../reference/serializer'
 require_relative '../bill_payment_line_item/serializer'
 
 module LedgerSync
@@ -14,18 +13,21 @@ module LedgerSync
           amount 'TotalAmt',
                  resource_attribute: :amount
 
-          references_one :CurrencyRef,
+          references_one 'CurrencyRef',
                          resource_attribute: :currency,
-                         serializer: Currency::Serializer
+                         serializer: Reference::Serializer
 
-          attribute 'VendorRef.value',
-                    resource_attribute: 'vendor.ledger_id'
+          references_one 'VendorRef',
+                         resource_attribute: :vendor,
+                         serializer: Reference::Serializer
 
-          attribute 'DepartmentRef.value',
-                    resource_attribute: 'department.ledger_id'
+          references_one 'DepartmentRef',
+                         resource_attribute: :department,
+                         serializer: Reference::Serializer
 
-          attribute 'APAccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'APAccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
           attribute 'DocNumber',
                     resource_attribute: :reference_number

--- a/lib/ledger_sync/ledgers/quickbooks_online/config.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/config.rb
@@ -2,7 +2,7 @@
 
 LedgerSync.register_ledger(:quickbooks_online, module_string: 'QuickBooksOnline') do |config|
   config.name = 'QuickBooks Online'
-  config.add_alias :qbo
-  config.add_alias :quick_books_online
+  # config.add_alias :qbo
+  # config.add_alias :quick_books_online
   config.rate_limiting_wait_in_seconds = 60
 end

--- a/lib/ledger_sync/ledgers/quickbooks_online/config.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/config.rb
@@ -2,7 +2,7 @@
 
 LedgerSync.register_ledger(:quickbooks_online, module_string: 'QuickBooksOnline') do |config|
   config.name = 'QuickBooks Online'
-  # config.add_alias :qbo
-  # config.add_alias :quick_books_online
+  config.add_alias :qbo
+  config.add_alias :quick_books_online
   config.rate_limiting_wait_in_seconds = 60
 end

--- a/lib/ledger_sync/ledgers/quickbooks_online/department/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/department/deserializer.rb
@@ -9,10 +9,13 @@ module LedgerSync
 
           attribute :name,
                     hash_attribute: 'Name'
+
           attribute :active,
                     hash_attribute: 'Active'
+
           attribute :sub_department,
                     hash_attribute: 'SubDepartment'
+
           attribute :fully_qualified_name,
                     hash_attribute: 'FullyQualifiedName'
 

--- a/lib/ledger_sync/ledgers/quickbooks_online/deposit/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/deposit/deserializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../deposit_line_item/deserializer'
-require_relative '../currency/deserializer'
+require_relative '../reference/deserializer'
 
 module LedgerSync
   module Ledgers
@@ -11,8 +11,8 @@ module LedgerSync
           id
 
           references_one :currency,
-                         hash_attribute: :CurrencyRef,
-                         deserializer: Currency::Deserializer
+                         hash_attribute: 'CurrencyRef',
+                         deserializer: Reference::Deserializer
 
           date :transaction_date,
                hash_attribute: 'TxnDate'
@@ -23,11 +23,13 @@ module LedgerSync
           attribute :exchange_rate,
                     hash_attribute: 'ExchangeRate'
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'DepositToAccountRef.value'
+          references_one :account,
+                         hash_attribute: 'DepositToAccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'department.ledger_id',
-                    hash_attribute: 'DepartmentRef.value'
+          references_one :department,
+                         hash_attribute: 'DepartmentRef',
+                         deserializer: Reference::Deserializer
 
           references_many :line_items,
                           hash_attribute: 'Line',

--- a/lib/ledger_sync/ledgers/quickbooks_online/deposit/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/deposit/serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../deposit_line_item/serializer'
-require_relative '../currency/serializer'
+require_relative '../reference/serializer'
 
 module LedgerSync
   module Ledgers
@@ -10,9 +10,9 @@ module LedgerSync
         class Serializer < QuickBooksOnline::Serializer
           id
 
-          references_one :CurrencyRef,
+          references_one 'CurrencyRef',
                          resource_attribute: :currency,
-                         serializer: Currency::Serializer
+                         serializer: Reference::Serializer
 
           date 'TxnDate',
                resource_attribute: :transaction_date
@@ -23,11 +23,13 @@ module LedgerSync
           attribute 'ExchangeRate',
                     resource_attribute: :exchange_rate
 
-          attribute 'DepositToAccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'DepositToAccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
-          attribute 'DepartmentRef.value',
-                    resource_attribute: 'department.ledger_id'
+          references_one 'DepartmentRef',
+                         resource_attribute: :department,
+                         serializer: Reference::Serializer
 
           references_many 'Line',
                           resource_attribute: :line_items,

--- a/lib/ledger_sync/ledgers/quickbooks_online/deposit_line_item/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/deposit_line_item/deserializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/deserializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -7,11 +9,13 @@ module LedgerSync
         class Deserializer < QuickBooksOnline::Deserializer
           id
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'DepositLineDetail.AccountRef.value'
+          references_one :account,
+                         hash_attribute: 'DepositLineDetail.AccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'ledger_class.ledger_id',
-                    hash_attribute: 'DepositLineDetail.ClassRef.value'
+          references_one :ledger_class,
+                         hash_attribute: 'DepositLineDetail.ClassRef',
+                         deserializer: Reference::Deserializer
 
           attribute(:entity) do |args = {}|
             hash = args.fetch(:hash)

--- a/lib/ledger_sync/ledgers/quickbooks_online/deposit_line_item/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/deposit_line_item/serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/serializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -9,11 +11,13 @@ module LedgerSync
 
           attribute('DetailType') { 'DepositLineDetail' }
 
-          attribute 'DepositLineDetail.AccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'DepositLineDetail.AccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
-          attribute 'DepositLineDetail.ClassRef.value',
-                    resource_attribute: 'ledger_class.ledger_id'
+          references_one 'DepositLineDetail.ClassRef',
+                         resource_attribute: :ledger_class,
+                         serializer: Reference::Serializer
 
           attribute('DepositLineDetail.Entity') do |args = {}|
             resource = args.fetch(:resource)

--- a/lib/ledger_sync/ledgers/quickbooks_online/expense/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/expense/deserializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../expense_line_item/deserializer'
-require_relative '../currency/deserializer'
+require_relative '../reference/deserializer'
 
 module LedgerSync
   module Ledgers
@@ -11,8 +11,8 @@ module LedgerSync
           id
 
           references_one :currency,
-                         hash_attribute: :CurrencyRef,
-                         deserializer: Currency::Deserializer
+                         hash_attribute: 'CurrencyRef',
+                         deserializer: Reference::Deserializer
 
           mapping :payment_type,
                   hash_attribute: 'PaymentType',
@@ -43,11 +43,13 @@ module LedgerSync
           attribute :reference_number,
                     hash_attribute: 'DocNumber'
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'AccountRef.value'
+          references_one :account,
+                         hash_attribute: 'AccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'department.ledger_id',
-                    hash_attribute: 'DepartmentRef.value'
+          references_one :department,
+                         hash_attribute: 'DepartmentRef',
+                         deserializer: Reference::Deserializer
 
           references_many :line_items,
                           hash_attribute: 'Line',

--- a/lib/ledger_sync/ledgers/quickbooks_online/expense/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/expense/serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../expense_line_item/serializer'
-require_relative '../currency/serializer'
+require_relative '../reference/serializer'
 
 module LedgerSync
   module Ledgers
@@ -10,9 +10,9 @@ module LedgerSync
         class Serializer < QuickBooksOnline::Serializer
           id
 
-          references_one :CurrencyRef,
+          references_one 'CurrencyRef',
                          resource_attribute: :currency,
-                         serializer: Currency::Serializer
+                         serializer: Reference::Serializer
 
           attribute 'PaymentType',
                     resource_attribute: :payment_type,
@@ -43,11 +43,13 @@ module LedgerSync
           attribute 'DocNumber',
                     resource_attribute: :reference_number
 
-          attribute 'AccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'AccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
-          attribute 'DepartmentRef.value',
-                    resource_attribute: 'department.ledger_id'
+          references_one 'DepartmentRef',
+                         resource_attribute: :department,
+                         serializer: Reference::Serializer
 
           references_many 'Line',
                           resource_attribute: :line_items,

--- a/lib/ledger_sync/ledgers/quickbooks_online/expense_line_item/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/expense_line_item/deserializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/deserializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -7,11 +9,13 @@ module LedgerSync
         class Deserializer < QuickBooksOnline::Deserializer
           id
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'AccountBasedExpenseLineDetail.AccountRef.value'
+          references_one :account,
+                         hash_attribute: 'AccountBasedExpenseLineDetail.AccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'ledger_class.ledger_id',
-                    hash_attribute: 'AccountBasedExpenseLineDetail.ClassRef.value'
+          references_one :ledger_class,
+                         hash_attribute: 'AccountBasedExpenseLineDetail.ClassRef',
+                         deserializer: Reference::Deserializer
 
           amount :amount,
                  hash_attribute: 'Amount'

--- a/lib/ledger_sync/ledgers/quickbooks_online/expense_line_item/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/expense_line_item/serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/serializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -9,11 +11,13 @@ module LedgerSync
 
           attribute('DetailType') { 'AccountBasedExpenseLineDetail' }
 
-          attribute 'AccountBasedExpenseLineDetail.AccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'AccountBasedExpenseLineDetail.AccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
-          attribute 'AccountBasedExpenseLineDetail.ClassRef.value',
-                    resource_attribute: 'ledger_class.ledger_id'
+          references_one 'AccountBasedExpenseLineDetail.ClassRef',
+                         resource_attribute: :ledger_class,
+                         serializer: Reference::Serializer
 
           amount 'Amount',
                  resource_attribute: :amount

--- a/lib/ledger_sync/ledgers/quickbooks_online/invoice/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/invoice/deserializer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../invoice_sales_line_item/deserializer'
+require_relative '../reference/deserializer'
 
 module LedgerSync
   module Ledgers
@@ -10,8 +11,8 @@ module LedgerSync
           id
 
           references_one :currency,
-                         hash_attribute: :CurrencyRef,
-                         deserializer: Currency::Deserializer
+                         hash_attribute: 'CurrencyRef',
+                         deserializer: Reference::Deserializer
 
           date :transaction_date,
                hash_attribute: 'TxnDate'
@@ -19,11 +20,13 @@ module LedgerSync
           attribute :memo,
                     hash_attribute: 'PrivateNote'
 
-          attribute 'customer.ledger_id',
-                    hash_attribute: 'CustomerRef.value'
+          references_one :customer,
+                         hash_attribute: 'CustomerRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'DepositToAccountRef.value'
+          references_one :account,
+                         hash_attribute: 'DepositToAccountRef',
+                         deserialier: Reference::Deserializer
 
           references_many :line_items,
                           hash_attribute: 'Line',

--- a/lib/ledger_sync/ledgers/quickbooks_online/invoice/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/invoice/serializer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../invoice_sales_line_item/serializer'
+require_relative '../reference/serializer'
 
 module LedgerSync
   module Ledgers
@@ -9,9 +10,9 @@ module LedgerSync
         class Serializer < QuickBooksOnline::Serializer
           id
 
-          references_one :CurrencyRef,
+          references_one 'CurrencyRef',
                          resource_attribute: :currency,
-                         serializer: Currency::Serializer
+                         serializer: Reference::Serializer
 
           date 'TxnDate',
                resource_attribute: :transaction_date
@@ -19,11 +20,13 @@ module LedgerSync
           attribute 'PrivateNote',
                     resource_attribute: :memo
 
-          attribute 'CustomerRef.value',
-                    resource_attribute: 'customer.ledger_id'
+          references_one 'CustomerRef',
+                         resource_attribute: :customer,
+                         serializer: Reference::Serializer
 
-          attribute 'DepositToAccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'DepositToAccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
           references_many 'Line',
                           resource_attribute: :line_items,

--- a/lib/ledger_sync/ledgers/quickbooks_online/invoice_sales_line_item/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/invoice_sales_line_item/deserializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/deserializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -7,11 +9,13 @@ module LedgerSync
         class Deserializer < QuickBooksOnline::Deserializer
           id
 
-          attribute 'item.ledger_id',
-                    hash_attribute: 'SalesItemLineDetail.ItemRef.value'
+          references_one :item,
+                         hash_attribute: 'SalesItemLineDetail.ItemRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'ledger_class.ledger_id',
-                    hash_attribute: 'SalesItemLineDetail.ClassRef.value'
+          references_one :ledger_class,
+                         hash_attribute: 'SalesItemLineDetail.ClassRef',
+                         deserializer: Reference::Deserializer
 
           amount :amount,
                  hash_attribute: 'Amount'

--- a/lib/ledger_sync/ledgers/quickbooks_online/invoice_sales_line_item/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/invoice_sales_line_item/serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/serializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -11,11 +13,13 @@ module LedgerSync
             'SalesItemLineDetail'
           end
 
-          attribute 'SalesItemLineDetail.ItemRef.value',
-                    resource_attribute: 'item.ledger_id'
+          references_one 'SalesItemLineDetail.ItemRef',
+                         resource_attribute: :item,
+                         serializer: Reference::Serializer
 
-          attribute 'SalesItemLineDetail.ClassRef.value',
-                    resource_attribute: 'ledger_class.ledger_id'
+          references_one 'SalesItemLineDetail.ClassRef',
+                         resource_attribute: :ledger_class,
+                         serializer: Reference::Serializer
 
           amount 'Amount',
                  resource_attribute: :amount

--- a/lib/ledger_sync/ledgers/quickbooks_online/journal_entry/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/journal_entry/deserializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/deserializer'
+require_relative '../reference/deserializer'
 require_relative '../journal_entry_line_item/deserializer'
 
 module LedgerSync
@@ -11,8 +11,8 @@ module LedgerSync
           id
 
           references_one :currency,
-                         hash_attribute: :CurrencyRef,
-                         deserializer: Currency::Deserializer
+                         hash_attribute: 'CurrencyRef',
+                         deserializer: Reference::Deserializer
 
           date :transaction_date,
                hash_attribute: 'TxnDate'

--- a/lib/ledger_sync/ledgers/quickbooks_online/journal_entry/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/journal_entry/serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/serializer'
+require_relative '../reference/serializer'
 require_relative '../journal_entry_line_item/serializer'
 
 module LedgerSync
@@ -10,9 +10,9 @@ module LedgerSync
         class Serializer < QuickBooksOnline::Serializer
           id
 
-          references_one :CurrencyRef,
+          references_one 'CurrencyRef',
                          resource_attribute: :currency,
-                         serializer: Currency::Serializer
+                         serializer: Reference::Serializer
 
           date 'TxnDate',
                resource_attribute: :transaction_date

--- a/lib/ledger_sync/ledgers/quickbooks_online/journal_entry_line_item/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/journal_entry_line_item/deserializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../expense_line_item/deserializer'
+require_relative '../reference/deserializer'
 
 module LedgerSync
   module Ledgers
@@ -14,14 +14,17 @@ module LedgerSync
                   hash_attribute: 'JournalEntryLineDetail.PostingType',
                   hash: JournalEntryLineItem::TYPES.invert
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'JournalEntryLineDetail.AccountRef.value'
+          references_one :account,
+                         hash_attribute: 'JournalEntryLineDetail.AccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'ledger_class.ledger_id',
-                    hash_attribute: 'JournalEntryLineDetail.ClassRef.value'
+          references_one :ledger_class,
+                         hash_attribute: 'JournalEntryLineDetail.ClassRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'department.ledger_id',
-                    hash_attribute: 'JournalEntryLineDetail.DepartmentRef.value'
+          references_one :department,
+                         hash_attribute: 'JournalEntryLineDetail.DepartmentRef',
+                         deserializer: Reference::Deserializer
 
           attribute :description,
                     hash_attribute: 'Description'

--- a/lib/ledger_sync/ledgers/quickbooks_online/journal_entry_line_item/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/journal_entry_line_item/serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../expense_line_item/serializer'
+require_relative '../reference/serializer'
 
 module LedgerSync
   module Ledgers
@@ -18,14 +18,17 @@ module LedgerSync
                   resource_attribute: :entry_type,
                   hash: JournalEntryLineItem::TYPES
 
-          attribute 'JournalEntryLineDetail.AccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'JournalEntryLineDetail.AccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
-          attribute 'JournalEntryLineDetail.ClassRef.value',
-                    resource_attribute: 'ledger_class.ledger_id'
+          references_one 'JournalEntryLineDetail.ClassRef',
+                         resource_attribute: :ledger_class,
+                         serializer: Reference::Serializer
 
-          attribute 'JournalEntryLineDetail.DepartmentRef.value',
-                    resource_attribute: 'department.ledger_id'
+          references_one 'JournalEntryLineDetail.DepartmentRef',
+                         resource_attribute: :department,
+                         serializer: Reference::Serializer
 
           attribute 'Description',
                     resource_attribute: :description

--- a/lib/ledger_sync/ledgers/quickbooks_online/ledger_class/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/ledger_class/deserializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/deserializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -19,8 +21,9 @@ module LedgerSync
           attribute :fully_qualified_name,
                     hash_attribute: 'FullyQualifiedName'
 
-          attribute 'parent.ledger_id',
-                    hash_attribute: 'ParentRef.value'
+          references_one :parent,
+                         hash_attribute: 'ParentRef',
+                         deserializer: Reference::Deserializer
         end
       end
     end

--- a/lib/ledger_sync/ledgers/quickbooks_online/ledger_class/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/ledger_class/serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../reference/serializer'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
@@ -15,8 +17,9 @@ module LedgerSync
                     resource_attribute: :sub_class
           attribute 'FullyQualifiedName',
                     resource_attribute: :fully_qualified_name
-          attribute 'ParentRef.value',
-                    resource_attribute: 'parent.ledger_id'
+          references_one 'ParentRef',
+                         resource_attribute: :parent,
+                         serializer: Reference::Serializer
         end
       end
     end

--- a/lib/ledger_sync/ledgers/quickbooks_online/payment/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/payment/deserializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/deserializer'
+require_relative '../reference/deserializer'
 require_relative '../payment_line_item/deserializer'
 
 module LedgerSync
@@ -14,17 +14,20 @@ module LedgerSync
                  hash_attribute: 'TotalAmt'
 
           references_one :currency,
-                         hash_attribute: :CurrencyRef,
-                         deserializer: Currency::Deserializer
+                         hash_attribute: 'CurrencyRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'customer.ledger_id',
-                    hash_attribute: 'CustomerRef.value'
+          references_one :customer,
+                         hash_attribute: 'CustomerRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'deposit_account.ledger_id',
-                    hash_attribute: 'DepositToAccountRef.value'
+          references_one :deposit_account,
+                         hash_attribute: 'DepositToAccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'account.ledger_id',
-                    hash_attribute: 'ARAccountRef.value'
+          references_one :account,
+                         hash_attribute: 'ARAccountRef',
+                         deserializer: Account::Deserializer
 
           attribute :reference_number,
                     hash_attribute: 'PaymentRefNum'

--- a/lib/ledger_sync/ledgers/quickbooks_online/payment/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/payment/serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/serializer'
+require_relative '../reference/serializer'
 require_relative '../payment_line_item/serializer'
 
 module LedgerSync
@@ -13,18 +13,21 @@ module LedgerSync
           amount 'TotalAmt',
                  resource_attribute: :amount
 
-          references_one :CurrencyRef,
+          references_one 'CurrencyRef',
                          resource_attribute: :currency,
-                         serializer: Currency::Serializer
+                         serializer: Reference::Serializer
 
-          attribute 'CustomerRef.value',
-                    resource_attribute: 'customer.ledger_id'
+          references_one 'CustomerRef',
+                         resource_attribute: :customer,
+                         serializer: Reference::Serializer
 
-          attribute 'DepositToAccountRef.value',
-                    resource_attribute: 'deposit_account.ledger_id'
+          references_one 'DepositToAccountRef',
+                         resource_attribute: :deposit_account,
+                         serializer: Reference::Serializer
 
-          attribute 'ARAccountRef.value',
-                    resource_attribute: 'account.ledger_id'
+          references_one 'ARAccountRef',
+                         resource_attribute: :account,
+                         serializer: Reference::Serializer
 
           attribute 'PaymentRefNum',
                     resource_attribute: :reference_number

--- a/lib/ledger_sync/ledgers/quickbooks_online/reference/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/reference/deserializer.rb
@@ -3,12 +3,9 @@
 module LedgerSync
   module Ledgers
     module QuickBooksOnline
-      class Currency
+      class Reference
         class Deserializer < QuickBooksOnline::Deserializer
-          attribute :symbol,
-                    hash_attribute: :value
-
-          attribute :name
+          attribute :ledger_id, hash_attribute: :value
         end
       end
     end

--- a/lib/ledger_sync/ledgers/quickbooks_online/reference/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/reference/serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module LedgerSync
+  module Ledgers
+    module QuickBooksOnline
+      class Reference
+        class Serializer < QuickBooksOnline::Serializer
+          attribute :value, resource_attribute: :ledger_id
+        end
+      end
+    end
+  end
+end

--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/currency.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/currency.rb
@@ -7,6 +7,10 @@ module LedgerSync
         attribute :exchange_rate, type: Type::Float
         attribute :name, type: Type::String
         attribute :symbol, type: Type::String
+
+        def ledger_id
+          symbol
+        end
       end
     end
   end

--- a/lib/ledger_sync/ledgers/quickbooks_online/transfer/deserializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/transfer/deserializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/deserializer'
+require_relative '../reference/deserializer'
 
 module LedgerSync
   module Ledgers
@@ -15,18 +15,20 @@ module LedgerSync
           attribute :memo,
                     hash_attribute: 'PrivateNote'
 
-          attribute 'from_account.ledger_id',
-                    hash_attribute: 'FromAccountRef.value'
+          references_one :from_account,
+                         hash_attribute: 'FromAccountRef',
+                         deserializer: Reference::Deserializer
 
-          attribute 'to_account.ledger_id',
-                    hash_attribute: 'ToAccountRef.value'
+          references_one :to_account,
+                         hash_attribute: 'ToAccountRef',
+                         deserializer: Reference::Deserializer
 
           date :transaction_date,
                hash_attribute: 'TxnDate'
 
           references_one :currency,
-                         hash_attribute: :CurrencyRef,
-                         deserializer: Currency::Deserializer
+                         hash_attribute: 'CurrencyRef',
+                         deserializer: Reference::Deserializer
         end
       end
     end

--- a/lib/ledger_sync/ledgers/quickbooks_online/transfer/serializer.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/transfer/serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../currency/serializer'
+require_relative '../reference/serializer'
 
 module LedgerSync
   module Ledgers
@@ -15,18 +15,20 @@ module LedgerSync
           attribute 'PrivateNote',
                     resource_attribute: :memo
 
-          attribute 'FromAccountRef.value',
-                    resource_attribute: 'from_account.ledger_id'
+          references_one 'FromAccountRef',
+                         resource_attribute: :from_account,
+                         serializer: Reference::Serializer
 
-          attribute 'ToAccountRef.value',
-                    resource_attribute: 'to_account.ledger_id'
+          references_one 'ToAccountRef',
+                         resource_attribute: :to_account,
+                         serializer: Reference::Serializer
 
           date 'TxnDate',
                resource_attribute: :transaction_date
 
-          references_one :CurrencyRef,
+          references_one 'CurrencyRef',
                          resource_attribute: :currency,
-                         serializer: Currency::Serializer
+                         serializer: Reference::Serializer
         end
       end
     end

--- a/spec/ledgers/quickbooks_online/account/serializer_spec.rb
+++ b/spec/ledgers/quickbooks_online/account/serializer_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe LedgerSync::Ledgers::QuickBooksOnline::Account::Serializer do
       'AcctNum' => number,
       'Classification' => LedgerSync::Ledgers::QuickBooksOnline::Account::CLASSIFICATIONS[classification],
       'CurrencyRef' => {
-        'name' => currency.name,
         'value' => currency.symbol
       },
       'Description' => description,

--- a/spec/ledgers/quickbooks_online/deserializer_spec.rb
+++ b/spec/ledgers/quickbooks_online/deserializer_spec.rb
@@ -118,9 +118,7 @@ RSpec.describe LedgerSync::Ledgers::QuickBooksOnline::Deserializer do
             'AccountRef' => {
               'value' => '64'
             },
-            'ClassRef' => {
-              'value' => nil
-            }
+            'ClassRef' => nil
           },
           'Description' => 'Lumber 1'
         },
@@ -132,9 +130,7 @@ RSpec.describe LedgerSync::Ledgers::QuickBooksOnline::Deserializer do
             'AccountRef' => {
               'value' => '64'
             },
-            'ClassRef' => {
-              'value' => nil
-            }
+            'ClassRef' => nil
           },
           'Description' => 'Lumber 2'
         }
@@ -170,9 +166,7 @@ RSpec.describe LedgerSync::Ledgers::QuickBooksOnline::Deserializer do
             'AccountRef' => {
               'value' => '64'
             },
-            'ClassRef' => {
-              'value' => nil
-            }
+            'ClassRef' => nil
           },
           'Description' => 'Lumber 1'
         },
@@ -181,12 +175,8 @@ RSpec.describe LedgerSync::Ledgers::QuickBooksOnline::Deserializer do
           'Amount' => nil,
           'Id' => nil,
           'AccountBasedExpenseLineDetail' => {
-            'AccountRef' => {
-              'value' => nil
-            },
-            'ClassRef' => {
-              'value' => nil
-            }
+            'AccountRef' => nil,
+            'ClassRef' => nil
           },
           'Description' => 'Testing 3'
         }

--- a/spec/ledgers/quickbooks_online/expense/serializer_spec.rb
+++ b/spec/ledgers/quickbooks_online/expense/serializer_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe LedgerSync::Ledgers::QuickBooksOnline::Expense::Serializer do
     {
       'Id' => nil,
       'CurrencyRef' => {
-        'name' => currency.name,
         'value' => currency.symbol
       },
       'DepartmentRef' => { 'value' => department.ledger_id },

--- a/spec/ledgers/quickbooks_online/operations/ledger_class/create_spec.rb
+++ b/spec/ledgers/quickbooks_online/operations/ledger_class/create_spec.rb
@@ -2,7 +2,8 @@
 
 require 'spec_helper'
 
-support :quickbooks_online_helpers
+support :quickbooks_online_helpers,
+        :operation_shared_examples
 
 RSpec.describe LedgerSync::Ledgers::QuickBooksOnline::LedgerClass::Operations::Create do
   include QuickBooksOnlineHelpers

--- a/spec/ledgers/quickbooks_online/operations/ledger_class/find_spec.rb
+++ b/spec/ledgers/quickbooks_online/operations/ledger_class/find_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 support :input_helpers,
+        :operation_shared_examples,
         :quickbooks_online_helpers
 
 RSpec.describe LedgerSync::Ledgers::QuickBooksOnline::LedgerClass::Operations::Find do

--- a/spec/ledgers/quickbooks_online/operations/ledger_class/update_spec.rb
+++ b/spec/ledgers/quickbooks_online/operations/ledger_class/update_spec.rb
@@ -2,8 +2,9 @@
 
 require 'spec_helper'
 
-support :input_helpers
-support :quickbooks_online_helpers
+support :input_helpers,
+        :operation_shared_examples,
+        :quickbooks_online_helpers
 
 RSpec.describe LedgerSync::Ledgers::QuickBooksOnline::LedgerClass::Operations::Update do
   include InputHelpers

--- a/spec/support/quickbooks_online_helpers.rb
+++ b/spec/support/quickbooks_online_helpers.rb
@@ -189,7 +189,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
       request_hash: {
         'Id' => nil,
         'TotalAmt' => 1.0,
-        'CurrencyRef' => { 'value' => 'USD', 'name' => 'United States Dollar' },
+        'CurrencyRef' => { 'value' => 'USD' },
         'VendorRef' => { 'value' => '123' },
         'DepartmentRef' => { 'value' => '123' },
         'APAccountRef' => { 'value' => '123' },
@@ -467,7 +467,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
       .with(
         body: { 'Id' => nil,
                 'TotalAmt' => 123.45,
-                'CurrencyRef' => { 'value' => 'USD', 'name' => 'United States Dollar' },
+                'CurrencyRef' => { 'value' => 'USD' },
                 'CustomerRef' => { 'value' => '123' },
                 'DepositToAccountRef' => { 'value' => '123' },
                 'ARAccountRef' => { 'value' => '123' },
@@ -709,7 +709,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
     stub_request(:post, 'https://sandbox-quickbooks.api.intuit.com/v3/company/realm_id/invoice')
       .with(
         body: { 'Id' => nil,
-                'CurrencyRef' => { 'value' => 'USD', 'name' => 'United States Dollar' },
+                'CurrencyRef' => { 'value' => 'USD' },
                 'TxnDate' => '2019-09-01',
                 'PrivateNote' => 'Memo 1',
                 'CustomerRef' => { 'value' => '123' },
@@ -960,7 +960,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
         body: { 'Vendor' =>
           { 'Balance' => 0,
             'Vendor1099' => false,
-            'CurrencyRef' => { 'value' => 'USD', 'name' => 'United States Dollar' },
+            'CurrencyRef' => { 'value' => 'USD' },
             'domain' => 'QBO',
             'sparse' => false,
             'Id' => '123',
@@ -1097,8 +1097,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             "Balance": 0,
             "Vendor1099": false,
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "domain": 'QBO',
             "sparse": false,
@@ -1138,9 +1137,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
           'Description' => 'This is Sample Account',
           'Active' => true,
           'CurrencyRef' => {
-            'value' => 'USD',
-            'name' => 'United States Dollar'
-
+            'value' => 'USD'
           }
         },
         headers: {
@@ -1165,8 +1162,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             "CurrentBalance": 0,
             "CurrentBalanceWithSubAccounts": 0,
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "domain": 'QBO',
             "sparse": false,
@@ -1194,8 +1190,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
           "AccountSubType": 'CashOnHand',
           "AcctNum": nil,
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           },
           "Classification": nil,
           "Description": 'This is Sample Account',
@@ -1223,8 +1218,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             "CurrentBalance": 0,
             "CurrentBalanceWithSubAccounts": 0,
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "domain": 'QBO',
             "sparse": false,
@@ -1266,8 +1260,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             "CurrentBalance": 0,
             "CurrentBalanceWithSubAccounts": 0,
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "domain": 'QBO',
             "sparse": false,
@@ -1315,8 +1308,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
                 "CurrentBalance": 0,
                 "CurrentBalanceWithSubAccounts": 0,
                 "CurrencyRef": {
-                  "value": 'USD',
-                  "name": 'United States Dollar'
+                  "value": 'USD'
                 },
                 "domain": 'QBO',
                 "sparse": false,
@@ -1348,8 +1340,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
           "CurrentBalance": 0,
           "CurrentBalanceWithSubAccounts": 0,
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           },
           "domain": 'QBO',
           "sparse": false,
@@ -1384,8 +1375,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             "CurrentBalance": 0,
             "CurrentBalanceWithSubAccounts": 0,
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "domain": 'QBO',
             "sparse": false,
@@ -1410,8 +1400,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
         body: {
           "Id": nil,
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           },
           "PaymentType": 'Cash',
           "TxnDate": '2019-09-01',
@@ -1515,8 +1504,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             },
             "TxnDate": '2019-09-01',
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo',
             "Line": [
@@ -1574,8 +1562,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
         body: {
           "Id": nil,
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           },
           "PaymentType": 'Cash',
           "TxnDate": '2019-09-01',
@@ -1678,8 +1665,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             },
             "TxnDate": '2019-09-01',
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo',
             "Line": [
@@ -1789,8 +1775,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             },
             "TxnDate": '2019-09-01',
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo',
             "Line": [
@@ -1848,8 +1833,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
         body: {
           "Id": '123',
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           },
           "PaymentType": 'Cash',
           "TxnDate": '2019-09-01',
@@ -1980,8 +1964,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             },
             "TxnDate": '2019-09-01',
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo',
             "Line": [
@@ -2041,8 +2024,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
         body: {
           "Id": nil,
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           },
           "TxnDate": '2019-09-01',
           "PrivateNote": 'Memo',
@@ -2121,8 +2103,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
               "name": 'Sample Department'
             },
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo',
             "Line": [
@@ -2202,8 +2183,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
               "name": 'Sample Department'
             },
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo',
             "Line": [
@@ -2255,8 +2235,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
         body: {
           "Id": '123',
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           },
           "TxnDate": '2019-09-01',
           "PrivateNote": 'Memo',
@@ -2341,8 +2320,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
               "name": 'Sample Department'
             },
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo',
             "Line": [
@@ -2405,8 +2383,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
           },
           "TxnDate": '2019-09-01',
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           }
         },
         headers: {
@@ -2440,8 +2417,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             },
             "TxnDate": '2019-09-01',
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo'
           },
@@ -2485,8 +2461,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             },
             "TxnDate": '2019-09-01',
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo'
           },
@@ -2513,8 +2488,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
           },
           "TxnDate": '2019-09-01',
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           },
           "domain": 'QBO',
           "sparse": false,
@@ -2555,8 +2529,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
             },
             "TxnDate": '2019-09-01',
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo'
           },
@@ -2574,8 +2547,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
         body: {
           "Id": nil,
           "CurrencyRef": {
-            "value": 'USD',
-            "name": 'United States Dollar'
+            "value": 'USD'
           },
           "DueDate": '2019-09-01',
           "PrivateNote": 'Memo',
@@ -2650,8 +2622,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
               "name": 'Sample Department'
             },
             "CurrencyRef": {
-              "value": 'USD',
-              "name": 'United States Dollar'
+              "value": 'USD'
             },
             "PrivateNote": 'Memo',
             "Line": [
@@ -2816,19 +2787,23 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
         body: {
           'Id' => '123',
           'CurrencyRef' => {
-            'value' => 'USD', 'name' => 'United States Dollar'
+            'value' => 'USD',
+            'name' => 'United States Dollar'
           },
           'DueDate' => '2019-09-01',
           'PrivateNote' => 'Memo',
           'TxnDate' => '2019-09-01',
           'VendorRef' => {
-            'value' => '123', 'name' => 'Sample Vendor'
+            'value' => '123',
+            'name' => 'Sample Vendor'
           },
           'APAccountRef' => {
-            'value' => '123', 'name' => 'Accounts Payable (A/P)'
+            'value' => '123',
+            'name' => 'Accounts Payable (A/P)'
           },
           'DepartmentRef' => {
-            'value' => '123', 'name' => 'Sample Department'
+            'value' => '123',
+            'name' => 'Sample Department'
           },
           'DocNumber' => 'Ref123',
           'Line' =>
@@ -2935,7 +2910,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
     stub_request(:post, 'https://sandbox-quickbooks.api.intuit.com/v3/company/realm_id/journalentry')
       .with(
         body: { 'Id' => nil,
-                'CurrencyRef' => { 'value' => 'USD', 'name' => 'United States Dollar' },
+                'CurrencyRef' => { 'value' => 'USD' },
                 'TxnDate' => '2019-09-01',
                 'PrivateNote' => 'Memo',
                 'DocNumber' => 'Ref123',
@@ -3306,7 +3281,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
                 'Active' => true,
                 'SubClass' => false,
                 'FullyQualifiedName' => nil,
-                'ParentRef' => { 'value' => nil } }.to_json,
+                'ParentRef' => nil }.to_json,
         headers: {
           'Accept' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
@@ -3408,7 +3383,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
                 'Active' => true,
                 'SubClass' => false,
                 'FullyQualifiedName' => nil,
-                'ParentRef' => { 'value' => nil },
+                'ParentRef' => nil,
                 'domain' => 'QBO',
                 'sparse' => false,
                 'SyncToken' => '0',


### PR DESCRIPTION
Unify how we reference one in QuickBooksOnline.

Instead of using `attribute` and setting ie `CustomerRef.value`, this uses `references_one` with `Reference::Serializer` and `Reference::Deserializer`. 