### PR TITLE
Namespaced resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
 before_install:
   - gem update --system
   - gem install bundler
-  - rm Gemfile.lock
   - bundle install
 script:
   - bundle exec rspec --order rand

--- a/lib/ledger_sync/ledgers/mixins/infer_config_mixin.rb
+++ b/lib/ledger_sync/ledgers/mixins/infer_config_mixin.rb
@@ -6,9 +6,9 @@ module LedgerSync
       module InferConfigMixin
         module ClassMethods
           def inferred_config
-            @inferred_config ||= begin
-              return if name.nil?
+            return if name.nil?
 
+            @inferred_config ||= begin
               name_parts = name.split('::')
               name_parts_length = name_parts.count
 

--- a/lib/ledger_sync/ledgers/mixins/infer_config_mixin.rb
+++ b/lib/ledger_sync/ledgers/mixins/infer_config_mixin.rb
@@ -17,7 +17,7 @@ module LedgerSync
               name_parts_length.times do |i|
                 config = LedgerSync.ledgers.config_from_base_module(
                   base_module: Object.const_get(
-                    name_parts[0..(name_parts_length - i)].join('::')
+                    name_parts[0..(name_parts_length - 1 - i)].join('::')
                   )
                 )
                 break if config.present?

--- a/lib/ledger_sync/ledgers/mixins/infer_resource_class_mixin.rb
+++ b/lib/ledger_sync/ledgers/mixins/infer_resource_class_mixin.rb
@@ -10,8 +10,11 @@ module LedgerSync
           def inferred_resource_class
             @inferred_resource_class ||= begin
               base_module = inferred_config.base_module
-
-              base_module.const_get(name.split(base_module.name).last.split('::')[1])
+              if name.include?('::Operations::')
+                base_module.const_get(name.split('::Operations::').first)
+              else
+                base_module.const_get(name.split(base_module.name).last.split('::')[1])
+              end
             end
           end
         end

--- a/lib/ledger_sync/ledgers/mixins/infer_serializer_mixin.rb
+++ b/lib/ledger_sync/ledgers/mixins/infer_serializer_mixin.rb
@@ -15,7 +15,7 @@ module LedgerSync
           end
 
           def inferred_deserializer_class_name
-            @inferred_deserializer_class_name ||= "#{inferred_resource_class.resource_module_str}::Deserializer"
+            @inferred_deserializer_class_name ||= "#{inferred_resource_class}::Deserializer"
           end
 
           def inferred_searcher_deserializer_class
@@ -26,7 +26,7 @@ module LedgerSync
 
           def inferred_searcher_deserializer_class_name
             @inferred_searcher_deserializer_class_name ||= begin
-              "#{inferred_resource_class.resource_module_str}::SearcherDeserializer"
+              "#{inferred_resource_class}::SearcherDeserializer"
             end
           end
 
@@ -39,7 +39,7 @@ module LedgerSync
           end
 
           def inferred_serializer_class_name
-            @inferred_serializer_class_name ||= "#{inferred_resource_class.resource_module_str}::Serializer"
+            @inferred_serializer_class_name ||= "#{inferred_resource_class}::Serializer"
           end
         end
 

--- a/lib/ledger_sync/ledgers/mixins/infer_serializer_mixin.rb
+++ b/lib/ledger_sync/ledgers/mixins/infer_serializer_mixin.rb
@@ -9,19 +9,25 @@ module LedgerSync
       module InferSerializerMixin
         module ClassMethods
           def inferred_deserializer_class
-            @inferred_deserializer_class ||= inferred_config.base_module.const_get(
-              inferred_deserializer_class_name
-            )
+            @inferred_deserializer_class ||= begin
+              inferred_config.base_module.const_get(
+                inferred_deserializer_class_name
+              )
+            end
           end
 
           def inferred_deserializer_class_name
-            @inferred_deserializer_class_name ||= "#{inferred_resource_class}::Deserializer"
+            @inferred_deserializer_class_name ||= begin
+              "#{inferred_resource_class}::Deserializer"
+            end
           end
 
           def inferred_searcher_deserializer_class
-            @inferred_searcher_deserializer_class ||= inferred_config.base_module.const_get(
-              inferred_searcher_deserializer_class_name
-            )
+            @inferred_searcher_deserializer_class ||= begin
+              inferred_config.base_module.const_get(
+                inferred_searcher_deserializer_class_name
+              )
+            end
           end
 
           def inferred_searcher_deserializer_class_name
@@ -39,7 +45,9 @@ module LedgerSync
           end
 
           def inferred_serializer_class_name
-            @inferred_serializer_class_name ||= "#{inferred_resource_class}::Serializer"
+            @inferred_serializer_class_name ||= begin
+              "#{inferred_resource_class}::Serializer"
+            end
           end
         end
 

--- a/lib/ledger_sync/ledgers/mixins/serialization_mixin.rb
+++ b/lib/ledger_sync/ledgers/mixins/serialization_mixin.rb
@@ -13,7 +13,7 @@ module LedgerSync
             type = args.fetch(:type)
 
             inferred_config.base_module.const_get(
-              "#{inferred_resource_class.resource_module_str}::#{type.camelcase}"
+              "#{inferred_resource_class}::#{type.camelcase}"
             )
           end
 

--- a/spec/ledgers/mixins/infer_resource_spec.rb
+++ b/spec/ledgers/mixins/infer_resource_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LedgerSync
+  module Test
+    class Config
+      def base_module
+          LedgerSync::Test
+      end
+    end
+
+    class MyResource
+      module Operations
+        class MyOperation
+          include LedgerSync::Ledgers::Mixins::InferResourceClassMixin
+
+          def self.inferred_config
+            LedgerSync::Test::Config.new
+          end
+        end
+      end
+
+      class Serializer
+        include LedgerSync::Ledgers::Mixins::InferResourceClassMixin
+
+        def self.inferred_config
+          LedgerSync::Test::Config.new
+        end
+      end
+    end
+  end
+end
+
+RSpec.describe LedgerSync::Ledgers::Mixins::InferResourceClassMixin do
+  describe 'infering resource from serializer' do
+    subject { LedgerSync::Test::MyResource::Serializer }
+
+    it do
+      expect(subject.inferred_resource_class).to eq(LedgerSync::Test::MyResource)
+    end
+  end
+
+  describe 'infering resource from operation' do
+    subject { LedgerSync::Test::MyResource::Operations::MyOperation }
+
+    it do
+      expect(subject.inferred_resource_class).to eq(LedgerSync::Test::MyResource)
+    end
+  end
+end

--- a/spec/ledgers/mixins/infer_resource_spec.rb
+++ b/spec/ledgers/mixins/infer_resource_spec.rb
@@ -6,7 +6,7 @@ module LedgerSync
   module Test
     class Config
       def base_module
-          LedgerSync::Test
+        LedgerSync::Test
       end
     end
 

--- a/spec/ledgers/mixins/infer_serializer_spec.rb
+++ b/spec/ledgers/mixins/infer_serializer_spec.rb
@@ -16,10 +16,17 @@ end
 
 RSpec.describe LedgerSync::Ledgers::Mixins::InferSerializerMixin do
   subject { LedgerSync::Test::ValidateInferSerializer }
+  let(:name) { 'LedgerSync::Test::MyResource' }
 
   it do
-    expect(subject.inferred_deserializer_class_name).to eq('LedgerSync::Test::MyResource::Deserializer')
-    expect(subject.inferred_searcher_deserializer_class_name).to eq('LedgerSync::Test::MyResource::SearcherDeserializer')
-    expect(subject.inferred_serializer_class_name).to eq('LedgerSync::Test::MyResource::Serializer')
+    expect(subject.inferred_deserializer_class_name).to eq(
+      'LedgerSync::Test::MyResource::Deserializer'
+    )
+    expect(subject.inferred_searcher_deserializer_class_name).to eq(
+      'LedgerSync::Test::MyResource::SearcherDeserializer'
+    )
+    expect(subject.inferred_serializer_class_name).to eq(
+      'LedgerSync::Test::MyResource::Serializer'
+    )
   end
 end

--- a/spec/ledgers/mixins/infer_serializer_spec.rb
+++ b/spec/ledgers/mixins/infer_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module LedgerSync
+  module Test
+    class ValidateInferSerializer
+      include LedgerSync::Ledgers::Mixins::InferSerializerMixin
+
+      def self.inferred_resource_class
+        'LedgerSync::Test::MyResource'
+      end
+    end
+  end
+end
+
+RSpec.describe LedgerSync::Ledgers::Mixins::InferSerializerMixin do
+  subject { LedgerSync::Test::ValidateInferSerializer }
+
+  it do
+    expect(subject.inferred_deserializer_class_name).to eq('LedgerSync::Test::MyResource::Deserializer')
+    expect(subject.inferred_searcher_deserializer_class_name).to eq('LedgerSync::Test::MyResource::SearcherDeserializer')
+    expect(subject.inferred_serializer_class_name).to eq('LedgerSync::Test::MyResource::Serializer')
+  end
+end

--- a/spec/support/quickbooks_online_helpers.rb
+++ b/spec/support/quickbooks_online_helpers.rb
@@ -129,6 +129,7 @@ module QuickBooksOnlineHelpers # rubocop:disable Metrics/ModuleLength
     end
 
     define_method(stub_delete_method) do |request_body: nil, response_body: nil|
+      # does nothing
     end
 
     define_method(stub_update_method) do |request_body: nil, response_body: nil|


### PR DESCRIPTION
As I was going through 1.5.2 I noticed that it doesn't work well with two cases

### Single level module name
If module was called `Xero` instead of `LedgerSync::Xero` (ie someone building their integration with LS), our `inferred_config` method didn't get the module right.

### Nested resources
I was thinking a lot how to do nested resources. For example `/api/customers` and also `/api/accounting/invoices`. Turned out it wasnt that much additional work. We load resources first through `resources/**/*.rb` so anything under `resources` as well as `resources/accounting` will get loaded first. Then we load everything else recursively.

So now you can have resource like `MyLedger::Customer` and `MyLedger::Accounting::Invoice`

The biggest issue was again inferring resource class. I made two changes
1. if we're inside of `Operation` it is easier to get resource by splitting on `::Operations::` instead of subtracting `base_module`.
2. to get serializer/deserializer we were using `resource_module_str` while we already had the inferred resource class.

I think its good convention to expect `MyModule::MyResource::Operations::*` as well as `MyModule::MyResource::Serializer` and `MyModule::MyResource::Deserializer`. Therefore we always have resource class above operations module and (de)serializer after resource class.