### PR TITLE
Fix QBO resources name and require relative references

### DIFF
--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/account_based_expense_line_detail.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/account_based_expense_line_detail.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'account'
+require_relative 'ledger_class'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline

--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/bill_line.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/bill_line.rb
@@ -11,7 +11,7 @@ module LedgerSync
         attribute :Description, type: Type::String
 
         def name
-          description
+          self.Description
         end
       end
     end

--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/check_payment.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/check_payment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'account'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline

--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/credit_card_payment.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/credit_card_payment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'account'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline

--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/department.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/department.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'department'
+
 module LedgerSync
   module Ledgers
     module QuickBooksOnline

--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/deposit_line.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/deposit_line.rb
@@ -11,7 +11,7 @@ module LedgerSync
         attribute :Description, type: Type::String
 
         def name
-          description
+          self.Description
         end
       end
     end

--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/expense.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/expense.rb
@@ -28,7 +28,7 @@ module LedgerSync
         references_many :Line, to: ExpenseLine
 
         def amount
-          line_items.map(&:amount).sum
+          line_items.inject(0) { |sum, li| sum + li.Amount }
         end
 
         def name

--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/invoice_line.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/invoice_line.rb
@@ -11,7 +11,7 @@ module LedgerSync
         attribute :Description, type: Type::String
 
         def name
-          description
+          self.Description
         end
       end
     end

--- a/lib/ledger_sync/ledgers/quickbooks_online/resources/payment.rb
+++ b/lib/ledger_sync/ledgers/quickbooks_online/resources/payment.rb
@@ -23,7 +23,7 @@ module LedgerSync
         references_many :Line, to: PaymentLine
 
         def name
-          "Payment: #{amount} #{currency}"
+          "Payment: #{self.TotalAmt} #{self.Currency}"
         end
       end
     end


### PR DESCRIPTION
This could be linux thing, but I hear that `account_based_expense_line_detail` is loaded before `account`. I noticed we don't have any `require_relative` there so I went ahead and checked the rest.

Also fixed `name` method still using old underscored attribute names.