### PR TITLE
Fix for dotenv missing import

### DIFF
--- a/lib/ledger_sync/util/dotenv_updator.rb
+++ b/lib/ledger_sync/util/dotenv_updator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dotenv'
+
 module LedgerSync
   module Util
     class DotenvUpdator


### PR DESCRIPTION
Attempt to fix this: https://sentry.io/organizations/modern-treasury/issues/2442175077/?project=1244199&referrer=slack