### PR TITLE
feat: allow request to use custom faraday client instance

### DIFF
--- a/lib/ledger_sync/ledgers/request.rb
+++ b/lib/ledger_sync/ledgers/request.rb
@@ -16,6 +16,7 @@ module LedgerSync
         @method = args.fetch(:method, nil)
         @params = args.fetch(:params, {})
         @url = args.fetch(:url, nil)
+        @faraday_client = args.fetch(:faraday_client, Faraday.new)
       end
 
       def perform
@@ -23,7 +24,7 @@ module LedgerSync
 
         url_with_params = Util::URLHelpers.merge_params_in_url(params: params, url: url)
 
-        faraday_response = Faraday.send(method, url_with_params) do |req|
+        faraday_response = @faraday_client.send(method, url_with_params) do |req|
           req.headers = headers
           req.body = body.to_json unless body.nil?
         end


### PR DESCRIPTION
Using global Faraday instance/configuration is a bit restrictive. 
You can't:
- have different configuration for different APIs (adapter, request timeout etc...) 
- pass your own faraday middleware (we use a middleware to log requests & responses)

For example you might want to use Faraday's `:test` [adapter](https://lostisland.github.io/faraday/adapters/testing) to mock requests during testing.

With this PR you can pass your custom configured Faraday client instance on your ledger's client and from there pass it to your request.

If you don't pass your own client, it defaults to creating an instance (which uses your global faraday default options).

