### PR TITLE
feat: normalize success and failure behaviour

### DIFF
--- a/lib/ledger_sync/ledgers/operation.rb
+++ b/lib/ledger_sync/ledgers/operation.rb
@@ -103,13 +103,12 @@ module LedgerSync
 
         # Results
 
-        def failure(error, resource: nil)
-          @response = error
+        def failure(error, resource: nil, response: nil)
           @result = LedgerSync::OperationResult.Failure(
             error,
             operation: self,
             resource: resource,
-            response: error
+            response: response
           )
         end
 
@@ -118,7 +117,6 @@ module LedgerSync
         end
 
         def success(resource:, response:)
-          @response = response
           @result = LedgerSync::OperationResult.Success(
             self,
             operation: self,


### PR DESCRIPTION
Currently `failure` and `success` operation methods enforce different value in `@result` which can conflict with operation itself.

This PR removes setting `@result` value and unifies attributes passed into `LedgerSync::OperationResult.Success` and `LedgerSync;:OperationResult.Failure`.

This is potentially breaking change depending how much one depends on value of `@result` variable.

Additional context:
```ruby
class MyOperation
  include LedgerSync::Ledgers::Operation::Mixin
  
  private
  def operate
    return failure(Error::OperationError.new(operation: self, message: 'Something went wrong')) if response.failure?

    success(resource: deserializer.deserialize(hash: response.body, resource: resource), response: response.body)
  end

  def response
    @response ||= client.get(...)
  end
end
```

This is a simple example, but it illustrates that when `response` is called first time, it holds result of `client.get` action. Once `success` is called it holds `response.body` value and if `failure` is called it will hold `error` instance itself.

I could easily have additional logic that is being evaluated after `perform`/`operate` and depends on value of `@response` variable, but depending on point of execution there can be 3 different types of content.
