### PR TITLE
Fix: Namespaced Resource key

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,76 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master", develop ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '38 21 * * 6'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'ruby' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #     echo "Run, Build Application using script"
+    #     ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/lib/ledger_sync/resource.rb
+++ b/lib/ledger_sync/resource.rb
@@ -80,7 +80,7 @@ module LedgerSync
     end
 
     def self.resource_module_str
-      @resource_module_str ||= name.split(inferred_config.base_module.name).last.gsub(/^(::)/, '')
+      @resource_module_str ||= name.split("#{inferred_config.base_module.name}::").last
     end
 
     def self.resource_type

--- a/lib/ledger_sync/resource.rb
+++ b/lib/ledger_sync/resource.rb
@@ -80,11 +80,7 @@ module LedgerSync
     end
 
     def self.resource_module_str
-      @resource_module_str ||= begin
-        name_part = name.split('::')
-
-        name_part.length > 2 ? "#{name_part[-2]}/#{name_part[-1]}" : name_part.last
-      end
+      @resource_module_str ||= name.split(inferred_config.base_module.name).last.gsub(/^(::)/, '')
     end
 
     def self.resource_type

--- a/lib/ledger_sync/resource.rb
+++ b/lib/ledger_sync/resource.rb
@@ -80,11 +80,15 @@ module LedgerSync
     end
 
     def self.resource_module_str
-      @resource_module_str ||= name.split('::').last
+      @resource_module_str ||= begin
+        name_part = name.split('::')
+
+        name_part.length > 2 ? "#{name_part[-2]}/#{name_part[-1]}" : name_part.last
+      end
     end
 
     def self.resource_type
-      @resource_type ||= LedgerSync::Util::StringHelpers.underscore(name.split('::').last).to_sym
+      @resource_type ||= LedgerSync::Util::StringHelpers.underscore(resource_module_str).to_sym
     end
 
     def self.serialize_attribute?(sattr)

--- a/spec/util/resources_builder_spec.rb
+++ b/spec/util/resources_builder_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe LedgerSync::Util::ResourcesBuilder do
   let(:mock_configuration) do
     LedgerSync::LedgerConfiguration.new(:test_ledger, {
                                           base_module: LedgerSync::TestResource,
-                                          root_path: File.join(LedgerSync.root, 'lib/ledger_sync/test/support/test_ledger')
+                                          root_path: File.join(
+                                            LedgerSync.root, 'lib/ledger_sync/test/support/test_ledger'
+                                          )
                                         })
   end
   before do

--- a/spec/util/resources_builder_spec.rb
+++ b/spec/util/resources_builder_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 module LedgerSync
-  class TestResource
+  module TestResource
     class ResourceWithDate < LedgerSync::Resource
       attribute :date_attr, type: Type::Date
     end
@@ -31,7 +31,6 @@ module LedgerSync
     end
   end
 end
-
 LedgerSync.register_resource(resource: LedgerSync::TestResource::ResourceWithDate)
 LedgerSync.register_resource(resource: LedgerSync::TestResource::TestUselessResource)
 LedgerSync.register_resource(resource: LedgerSync::TestResource::TestGrandchildResource)
@@ -39,6 +38,20 @@ LedgerSync.register_resource(resource: LedgerSync::TestResource::TestChildResour
 LedgerSync.register_resource(resource: LedgerSync::TestResource::TestParentResource)
 
 RSpec.describe LedgerSync::Util::ResourcesBuilder do
+  let(:mock_configuration) do
+    LedgerSync::LedgerConfiguration.new(:test_ledger, {
+                                          base_module: LedgerSync::TestResource,
+                                          root_path: File.join(LedgerSync.root, 'lib/ledger_sync/test/support/test_ledger')
+                                        })
+  end
+  before do
+    allow(LedgerSync::TestResource::ResourceWithDate).to receive(:inferred_config).and_return(mock_configuration)
+    allow(LedgerSync::TestResource::TestUselessResource).to receive(:inferred_config).and_return(mock_configuration)
+    allow(LedgerSync::TestResource::TestGrandchildResource).to receive(:inferred_config).and_return(mock_configuration)
+    allow(LedgerSync::TestResource::TestChildResource).to receive(:inferred_config).and_return(mock_configuration)
+    allow(LedgerSync::TestResource::TestParentResource).to receive(:inferred_config).and_return(mock_configuration)
+  end
+
   context 'with date' do
     let(:data) do
       {


### PR DESCRIPTION
**Why ?**

When we have a genuine scenario to have same class name under different folder, current `resource_module_str` method prevents to have same class name.
<img width="342" alt="Screenshot 2023-06-07 at 11 39 16 AM" src="https://github.com/LedgerSync/ledger_sync/assets/3069900/5fb0da98-498c-4155-9adb-d29b5392a2f2">


Look at the above structure. Here we have resource `shipping_address` under `marketplace` and root `resources` folder. With the current `resource_module_str` implementation of just taking the class name we end up in below error.

```bash
`rescue in block (2 levels) in require': There was an error while trying to load the gem 'desertcart'. (Bundler::GemRequireError)
Gem Load Error is: Resource key shipping_address already exists.
Backtrace for gem load error is:                    
/Users/jamsheed/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/bundler/gems/ledger_sync-095cf8d36086/lib/ledger_sync/util/mixins/resource_registerable_mixin.rb:10:in `register_resource'
/Users/jamsheed/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/bundler/gems/ledger_sync-095cf8d36086/lib/ledger_sync/resource.rb:73:in `inherited'        
/Users/jamsheed/sandbite/desertcart-ruby/lib/desertcart/resources/shipping_address.rb:4:in `<module:Desertcart>'
/Users/jamsheed/sandbite/desertcart-ruby/lib/desertcart/resources/shipping_address.rb:3:in `<main>'
/Users/jamsheed/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/bootsnap-1.14.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
``` 
**Fix**
Rather than taking the class name as key, this PR attempts to have a namespaced key by extracting everything after the `base_module` name to key.

