### PR TITLE
Update ruby publish version

### DIFF
--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Ruby Setup and Bundle
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.5
+          ruby-version: 3.1.6
           bundler-cache: true
       - name: Publish to RubyGems
         run: |


### PR DESCRIPTION
The Ruby Setup and Bundle step was failing as 2.7.5 is EOL. 