### PR TITLE
Drop ruby 3.1

### DIFF
--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Bundle install
         run: |
           gem install bundler
-          bundle config set frozen false
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - name: Rubocop
@@ -48,7 +47,6 @@ jobs:
       - name: Bundle install
         run: |
           gem install bundler
-          bundle config set frozen false
           bundle update
           bundle install
       - name: rspec and report to coveralls
@@ -77,7 +75,6 @@ jobs:
       - name: Bundle install
         run: |
           gem install bundler
-          bundle config set frozen false
           bundle install
       - name: Publish to RubyGems
         run: |

--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: ['3.1.6', '3.2.6', '3.3.6']
+        ruby-version: ["3.1.6", "3.2.6", "3.3.6"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev libxml2 libxslt1-dev libgmp-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev libxml2 libxml2-dev libxslt1-dev libgmp-dev pkg-config
       - name: Bundle install
         run: |
           gem install bundler
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: ['3.1.6', '3.2.6', '3.3.6']
+        ruby-version: ["3.1.6", "3.2.6", "3.3.6"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -42,16 +42,17 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev libxml2 libxslt1-dev libgmp-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev libxml2 libxml2-dev libxslt1-dev libgmp-dev pkg-config
       - name: Ruby Setup and Bundle
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-          run: |
-            gem install bundler
-            bundle update
-            bundle install
+      - name: Bundle install
+        run: |
+          gem install bundler
+          bundle update
+          bundle install
       - name: rspec and report to coveralls
         run: bundle exec rspec --order rand
       - name: Coveralls

--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev libxml2 libxslt1-dev libgmp-dev
       - name: Bundle install
         run: |
           gem install bundler

--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -21,11 +21,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: Bundle install
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
       - name: Rubocop
         run: bundle exec rubocop
   rspec:
@@ -44,11 +39,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: Bundle install
-        run: |
-          gem install bundler
-          bundle update
-          bundle install
       - name: rspec and report to coveralls
         run: bundle exec rspec --order rand
       - name: Coveralls
@@ -72,10 +62,6 @@ jobs:
         with:
           ruby-version: 3.2.6
           bundler-cache: true
-      - name: Bundle install
-        run: |
-          gem install bundler
-          bundle install
       - name: Publish to RubyGems
         run: |
           mkdir -p $HOME/.gem

--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Bundle install
         run: |
           gem install bundler
+          bundle config set frozen false
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - name: Rubocop
@@ -47,6 +48,7 @@ jobs:
       - name: Bundle install
         run: |
           gem install bundler
+          bundle config set frozen false
           bundle update
           bundle install
       - name: rspec and report to coveralls
@@ -72,6 +74,11 @@ jobs:
         with:
           ruby-version: 3.2.6
           bundler-cache: true
+      - name: Bundle install
+        run: |
+          gem install bundler
+          bundle config set frozen false
+          bundle install
       - name: Publish to RubyGems
         run: |
           mkdir -p $HOME/.gem

--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: ["3.1.6", "3.2.6", "3.3.6"]
+        ruby-version: ["3.2.6", "3.3.6"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: ["3.1.6", "3.2.6", "3.3.6"]
+        ruby-version: ["3.2.6", "3.3.6"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
       - name: Ruby Setup and Bundle
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.6
+          ruby-version: 3.2.6
           bundler-cache: true
       - name: Publish to RubyGems
         run: |

--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev libxml2 libxml2-dev libxslt1-dev libgmp-dev pkg-config
       - name: Bundle install
         run: |
           gem install bundler
@@ -41,8 +39,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev libxml2 libxml2-dev libxslt1-dev libgmp-dev pkg-config
       - name: Ruby Setup and Bundle
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev libxml2 libxslt1-dev libgmp-dev
       - name: Ruby Setup and Bundle
         uses: ruby/setup-ruby@v1
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   Exclude:
     - "documentation/site/_plugins/**/*"
     - "vendor/**/*"
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   NewCops: enable
 
 Gemspec/DevelopmentDependencies:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,21 +124,7 @@ GEM
     mize (0.6.1)
     net-http (0.6.0)
       uri
-    nokogiri (1.18.10-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.10-aarch64-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.18.10-arm-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.10-arm-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.18.10-arm64-darwin)
-      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
     observer (0.1.2)
     openssl (3.3.1)
@@ -234,14 +220,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  aarch64-linux-gnu
-  aarch64-linux-musl
-  arm-linux-gnu
-  arm-linux-musl
-  arm64-darwin
-  x86_64-darwin
-  x86_64-linux-gnu
-  x86_64-linux-musl
+  x86_64-darwin-24
 
 DEPENDENCIES
   awesome_print

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,21 @@ GEM
     mize (0.6.1)
     net-http (0.6.0)
       uri
+    nokogiri (1.18.10-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
     observer (0.1.2)
     openssl (3.3.1)
@@ -220,7 +234,14 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  x86_64-darwin-24
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   awesome_print

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,9 +19,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.2.2.2)
-      activesupport (= 7.2.2.2)
-    activesupport (7.2.2.2)
+    activemodel (8.0.3)
+      activesupport (= 8.0.3)
+    activesupport (8.0.3)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -33,6 +33,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,8 +123,10 @@ GEM
     minitest (5.25.5)
     net-http (0.6.0)
       uri
-    nokogiri (1.16.7)
+    nokogiri (1.18.7)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.7-x86_64-darwin)
       racc (~> 1.4)
     observer (0.1.2)
     openssl (3.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     awesome_print (1.9.2)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.3.1)
     bump (0.10.0)
     byebug (12.0.0)
     childprocess (5.1.0)
@@ -47,7 +47,7 @@ GEM
     climate_control (1.2.0)
     colorize (1.1.0)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.3)
+    connection_pool (2.5.4)
     coveralls_reborn (0.29.0)
       simplecov (~> 0.22.0)
       term-ansicolor (~> 1.7)
@@ -83,7 +83,7 @@ GEM
       dry-logic (~> 1.5)
       dry-types (~> 1.8)
       zeitwerk (~> 2.6)
-    dry-types (1.8.2)
+    dry-types (1.8.3)
       bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0)
@@ -96,6 +96,7 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
+    erb (5.1.1)
     factory_bot (6.5.5)
       activesupport (>= 6.1.0)
     faraday (2.14.0)
@@ -106,27 +107,38 @@ GEM
       net-http (>= 0.5.0)
     fingerprintable (1.2.1)
       colorize
-    hashdiff (1.1.2)
+    hashdiff (1.2.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
-    io-console (0.8.0)
+    io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.15.0)
+    json (2.15.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    mini_portile2 (2.8.8)
-    minitest (5.25.5)
+    minitest (5.26.0)
+    mize (0.6.1)
     net-http (0.6.0)
       uri
-    nokogiri (1.18.7)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.7-x86_64-darwin)
+    nokogiri (1.18.10-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
     observer (0.1.2)
     openssl (3.3.1)
@@ -140,30 +152,32 @@ GEM
       racc
     pd_ruby (0.2.3)
       colorize
-    pp (0.6.2)
+    pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.5.1)
-    psych (5.2.3)
+    prism (1.5.2)
+    psych (5.2.6)
       date
       stringio
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     racc (1.8.1)
     rack (3.2.3)
     rainbow (3.1.1)
     rake (13.3.0)
-    rdoc (6.13.1)
+    rdoc (6.15.0)
+      erb
       psych (>= 4.0.0)
+      tsort
     regexp_parser (2.11.3)
-    reline (0.6.1)
+    reline (0.6.2)
       io-console (~> 0.5)
     resonad (1.4.0)
-    rexml (3.4.2)
+    rexml (3.4.4)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -171,7 +185,7 @@ GEM
     rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.4)
+    rspec-support (3.13.6)
     rubocop (1.81.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -192,34 +206,42 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.1)
+    simplecov-html (0.13.2)
     simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
     simply_serializable (1.5.1)
       fingerprintable (>= 1.2.1)
-    stringio (3.1.6)
+    stringio (3.1.7)
     sync (0.5.0)
-    term-ansicolor (1.11.2)
-      tins (~> 1.0)
+    term-ansicolor (1.11.3)
+      tins (~> 1)
     thor (1.4.0)
-    tins (1.38.0)
+    tins (1.44.1)
       bigdecimal
+      mize (~> 0.6)
       sync
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
-    uri (1.0.3)
+    uri (1.0.4)
     webmock (3.25.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.3)
 
 PLATFORMS
-  ruby
-  x86_64-darwin-19
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   awesome_print
@@ -235,10 +257,10 @@ DEPENDENCIES
   overcommit (~> 0.68.0)
   rake (~> 13.0)
   rspec (~> 3.2)
-  rubocop (~> 1.81)
+  rubocop (~> 1.81, ~> 1.79)
   simplecov
   simplecov-lcov
   webmock
 
 BUNDLED WITH
-   2.6.2
+   2.7.1

--- a/documentation/generators/generator.rb
+++ b/documentation/generators/generator.rb
@@ -21,15 +21,15 @@ module Docs
         nl
       end
 
-      def cp(src, dest, *args)
+      def cp(src, dest, *)
         yellow "Copying #{src} to #{dest}"
-        FileUtils.cp_r(src, dest, *args)
+        FileUtils.cp_r(src, dest, *)
         green "Copied #{src} to #{dest}"
         nl
       end
 
-      def destination_path(*args, **keywords)
-        docs_path(*args, format: :md, **keywords)
+      def destination_path(*, **keywords)
+        docs_path(*, format: :md, **keywords)
       end
 
       def docs_path(*path, format: nil)

--- a/ledger_sync.gemspec
+++ b/ledger_sync.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.name = 'ledger_sync'
   spec.version = LedgerSync.version
 
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.2'
 
   # spec.required_rubygems_version = Gem::Requirement.new('>= 0') if spec.respond_to? :required_rubygems_version=
   spec.authors = ['Ryan Jackson']

--- a/lib/ledger_sync.rb
+++ b/lib/ledger_sync.rb
@@ -107,8 +107,8 @@ module LedgerSync
     @logger = val
   end
 
-  def self.register_ledger(*args)
-    ledger_config = LedgerSync::LedgerConfiguration.new(*args)
+  def self.register_ledger(*)
+    ledger_config = LedgerSync::LedgerConfiguration.new(*)
 
     yield(ledger_config)
 

--- a/lib/ledger_sync/error/ledger_errors.rb
+++ b/lib/ledger_sync/error/ledger_errors.rb
@@ -53,11 +53,11 @@ module LedgerSync
       class UnknownURLFormat < self
         attr_reader :resource
 
-        def initialize(*args, resource:, **keywords)
+        def initialize(*, resource:, **keywords)
           @resource = resource
 
           super(
-            *args,
+            *,
             message: "Unknown URL format for #{resource.class}", **keywords
           )
         end

--- a/lib/ledger_sync/ledger_configuration.rb
+++ b/lib/ledger_sync/ledger_configuration.rb
@@ -48,14 +48,14 @@ module LedgerSync
 
     # Delegate #new to the client class enabling faster client initialization
     # e.g. LedgerSync.ledgers.test.new(...)
-    def new(*args)
-      client_class.new(*args)
+    def new(*)
+      client_class.new(*)
     end
 
     # Delegate #new_from_env to the client class enabling faster client initialization
     # e.g. LedgerSync.ledgers.test.new_from_env(...)
-    def new_from_env(*args)
-      client_class.new_from_env(*args)
+    def new_from_env(*)
+      client_class.new_from_env(*)
     end
 
     def test?

--- a/lib/ledger_sync/ledgers/client.rb
+++ b/lib/ledger_sync/ledgers/client.rb
@@ -56,8 +56,8 @@ module LedgerSync
             )
           end
 
-          def searcher_class_for(*args, **keywords)
-            self.class.searcher_class_for(*args, **keywords)
+          def searcher_class_for(*, **keywords)
+            self.class.searcher_class_for(*, **keywords)
           end
 
           def url_for(*_args)
@@ -93,8 +93,8 @@ module LedgerSync
             {}
           end
 
-          def operation_class_for(*args, **keywords)
-            Client.operation_class_for(*args, **keywords)
+          def operation_class_for(*, **keywords)
+            Client.operation_class_for(*, **keywords)
           end
 
           def resource_from_ledger_type(type:, converter: nil)

--- a/lib/ledger_sync/result.rb
+++ b/lib/ledger_sync/result.rb
@@ -3,12 +3,12 @@
 module LedgerSync
   module ResultBase
     module HelperMethods
-      def Success(value = nil, *args, **keywords) # rubocop:disable Naming/MethodName
-        self::Success.new(value, *args, **keywords)
+      def Success(value = nil, *, **keywords) # rubocop:disable Naming/MethodName
+        self::Success.new(value, *, **keywords)
       end
 
-      def Failure(error = nil, *args, **keywords) # rubocop:disable Naming/MethodName
-        self::Failure.new(error, *args, **keywords)
+      def Failure(error = nil, *, **keywords) # rubocop:disable Naming/MethodName
+        self::Failure.new(error, *, **keywords)
       end
     end
 
@@ -25,8 +25,8 @@ module LedgerSync
 
   class Result
     module ResultTypeBase
-      def initialize(*args, **keywords) # rubocop:disable Lint/UnusedMethodArgument
-        super(*args)
+      def initialize(*, **keywords) # rubocop:disable Lint/UnusedMethodArgument
+        super(*)
       end
     end
 
@@ -43,11 +43,11 @@ module LedgerSync
         end
       end
 
-      def initialize(*args, **keywords)
+      def initialize(*, **keywords)
         @operation = keywords.fetch(:operation)
         @resource = keywords.fetch(:resource)
         @response = keywords.fetch(:response)
-        super(*args)
+        super(*)
       end
     end
 
@@ -69,10 +69,10 @@ module LedgerSync
         end
       end
 
-      def initialize(*args, searcher:, **keywords) # rubocop:disable Lint/UnusedMethodArgument
+      def initialize(*, searcher:, **keywords) # rubocop:disable Lint/UnusedMethodArgument
         @resources = searcher.resources
         @searcher = searcher
-        super(*args)
+        super(*)
       end
 
       def next_searcher

--- a/lib/ledger_sync/test/support/factory_bot.rb
+++ b/lib/ledger_sync/test/support/factory_bot.rb
@@ -143,8 +143,8 @@ end
 #
 # @return [String]
 #
-def rand_id(*args)
-  FactoryBot.rand_id(*args)
+def rand_id(*)
+  FactoryBot.rand_id(*)
 end
 
 #
@@ -152,6 +152,6 @@ end
 #
 # @return [String]
 #
-def test_run_id(*args)
-  @test_run_id ||= FactoryBot.test_run_id(*args)
+def test_run_id(*)
+  @test_run_id ||= FactoryBot.test_run_id(*)
 end

--- a/lib/ledger_sync/test/support/qa/ledger_helpers.rb
+++ b/lib/ledger_sync/test/support/qa/ledger_helpers.rb
@@ -4,8 +4,8 @@ module LedgerSync
   module Test
     module QA
       module LedgerHelpers
-        def create_resource_for(*args)
-          create_result_for(*args).raise_if_error.resource
+        def create_resource_for(*)
+          create_result_for(*).raise_if_error.resource
         end
 
         def create_result_for(client:, resource:)
@@ -16,8 +16,8 @@ module LedgerSync
           )
         end
 
-        def delete_resource_for(*args)
-          delete_result_for(*args).raise_if_error.resource
+        def delete_resource_for(*)
+          delete_result_for(*).raise_if_error.resource
         end
 
         def delete_result_for(client:, resource:)
@@ -28,8 +28,8 @@ module LedgerSync
           )
         end
 
-        def find_resource_for(*args)
-          find_result_for(*args).raise_if_error.resource
+        def find_resource_for(*)
+          find_result_for(*).raise_if_error.resource
         end
 
         def find_result_for(client:, resource:)
@@ -47,8 +47,8 @@ module LedgerSync
           ).perform
         end
 
-        def update_resource_for(*args)
-          update_result_for(*args).raise_if_error.resource
+        def update_resource_for(*)
+          update_result_for(*).raise_if_error.resource
         end
 
         def update_result_for(client:, resource:)

--- a/lib/ledger_sync/test/support/webmock_helpers.rb
+++ b/lib/ledger_sync/test/support/webmock_helpers.rb
@@ -12,9 +12,9 @@ module WebMock
   module API
     # Overwrite the original stub_request method to enforce we explicitly say
     # how many times we expect a request to be called
-    def stub_request(*args, times: 1)
+    def stub_request(*, times: 1)
       ret = WebMock::StubRegistry.instance
-                                 .register_request_stub(WebMock::RequestStub.new(*args))
+                                 .register_request_stub(WebMock::RequestStub.new(*))
       stubs_and_times << [ret, times] unless times.nil?
       ret
     end


### PR DESCRIPTION
-  Drop support for ruby 3.1 to be able to update nokogiri to 1.18 to fix the security issues.
 - Updated ci workflow to remove problematic bundle update.
 - Fixed rubocop 
 - Bump activemodel and activesupport and bump other gems.